### PR TITLE
Scores added remaining date_sort and year_filter to objects.yaml third pages

### DIFF
--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -7012,8 +7012,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "“Materials for Performance,” notes for a workshop in Yvonne  Rainer’s studio"
     date: "ca. 1969"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1969-01-01"
+    year_filter: [ "1969" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 6"
     extended_caption: ""
@@ -7057,8 +7057,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notes on arms, hands, legs, and feet, from Yvonne Rainer’s dance scripts notebook"
     date: "ca. 1962"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-01-01"
+    year_filter: [ "1962" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 30, folder 10"
     extended_caption: "These notebook pages show Yvonne Rainer using language as a tool to both deconstruct and rediscover the body’s possibilities for movement, much like the American sculptor Richard Serra would do in 1967 with his text piece *Verb List*, which spells out the available terms of his sculptural process. Rainer’s notes evoke the intertwined conversations between dance, object-making, poetry, and music in this time period and point to the underacknowledged influence of dance in particular on the minimal and postminimal art forms that would appear later in the decade."
@@ -7072,8 +7072,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notes related to *Three Satie Spoons*, *The Bells*, and *Ordinary Dance*"
     date: "1961–62"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-01"
+    year_filter: [ "1961", "1962" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 30, folder 1"
     extended_caption: ""
@@ -7117,8 +7117,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notebook sketches for *Three Satie Spoons* and *Satie for Two*"
     date: "1961–62"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-01"
+    year_filter: [ "1961", "1962" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 1, folder 4"
     extended_caption: "These notebook sketches show Yvonne Rainer combining multiple forms of scoring and description in order to articulate the dances *Three Satie Spoons* (1961), *The Bells* (1961), and [*Satie for Two*](/image-index/452/) (1962). There are aerial views of a hypothetical performance space marked by lines showing the trajectories of individual dancers. Color-coded tables list out the count lengths of certain movement sequences. Figure studies and stick figures show how a body should pose at specific moments. And there are elaborate textual descriptions that read as if Rainer were speaking them aloud as she was teaching or watching the dance."
@@ -7147,8 +7147,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notes related to *The Mind Is a Muscle*, including *Trio A* and *Trio B*"
     date: "1965–66"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-01-01"
+    year_filter: [ "1965", "1966" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 1, folder 9"
     extended_caption: "These notebook pages contain some of Yvonne Rainer’s earliest narrative descriptions of the choreography for [*Trio A*](/image-index/440/) (1966) and [*Trio B*](/image-index/454/) (1968), as well as ideas for how to engage with objects, sound, and light, which all come into play in her evolving multimedia work [*The Mind Is a Muscle*](/image-index/456/) (1966–68)."
@@ -7162,8 +7162,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)", "Melanie Clark and Joukje Kolff (notators)" ]
     title: "Labanotation score for Yvonne Rainer’s *Trio A* (1966), as performed at London International Summer School"
     date: "2003–5"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "2003-01-01"
+    year_filter: [ "2003", "2004", "2005" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 8"
     extended_caption: "This score for [*Trio A*](/image-index/440/) was created by notators trained in Labanotation, a form of dance notation first developed by the Austro-Hungarian dance theorist Rudolf von Laban in the 1920s. Labanotation remains the most widely used standardized form of dance notation that exists, although it has not been adopted to the extent that staff notation has in the discipline of music. In the main, dance practitioners rely on rehearsal, muscle memory, and body-to-body transmission alongside moving-image documentation and personal note-taking systems. Yvonne Rainer has written: “If the thought of having *Trio A* Laban notated had ever crossed my mind, it was only with the conviction that such a venture would be quite impossible. The subtleties and dynamics of this dance, performed without the structuring support of a musical score, seemed outside the domain of any graphic notation system. But when the opportunity arose in conjunction with teaching *Trio A* at the Greenwich Dance Agency in the summer of 2003, I did not object; in fact, I was curious. The notators were Joukje Kolff and Melanie Clarke. Their intense devotion to and completion of the task have given rise to some ruminations about conservation and immortality” (Rainer, “*Trio A*: Genealogy, Documentation, Notation,” *Dance Research Journal* 41, no. 2 [Winter 2009]: 16). "
@@ -7253,8 +7253,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "“Journal of the Identical Lunch,” *The Outsider* 2, no. 4/5 (Winter 1968/69): 182–84"
     date: "1968–69"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1968-01-01"
+    year_filter: [ "1968", "1969" ]
     medium: ""
     location: ""
     extended_caption: "Alison Knowles first published the score for *The Identical Lunch* in the last issue of *The Outsider*, a primarily Beat literary magazine published in small batches by Gypsy Lou and Jon Edgar Webb of the Loujon Press in New Orleans. Knowles’s text is joined by the work of colleagues Allan Kaprow, Dick Higgins, Jackson Mac Low, and Emmett Williams, but the more numerous texts by Beat writers in the issue strike an instructive counterpoint to Knowles’s quasi-objective and seemingly systematic reporting. While the Beat writers similarly dwell on everyday life in artist enclaves and working-class neighborhoods, they do so in a lyrical and markedly subjective way."
@@ -7330,8 +7330,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "*George Maciunas Performs The Identical Lunch*"
     date: "1969, realized 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1969-01-01"
+    year_filter: [ "1969", "1973" ]
     medium: "screenprint with hand additions"
     location: ""
     extended_caption: "Alison Knowles made these photo-silkscreen portraits in the early 1970s based on a series of Polaroids she had taken of her friends and audience members performing [*The Identical Lunch*](/image-index/479/) at the New Year’s Eve Flux-Feast at the Fluxhouse Cooperative in SoHo in 1969. Knowles recalled in a 2008 interview with the art historian Jessica Santone, “I got a shower curtain and I isolated a little space in the corner of the room and then I invited particular people to come and I served them a lunch. I had a toaster in there, and I’d mixed up the tuna fish and I had the lettuce. They’d sit down and eat the lunch there and I’d take a Polaroid of them eating and then they could talk to me about whatever” (Alison Knowles, in discussion with Jessica Lynne Santone, 22 October 2008, in Jessica Lynne Santone, “Circulating the Event: The Social Life of Performance Documentation, 1965–1975” [PhD diss., McGill University, 2010], 102). Overall, the portraits strike a balance between individual difference and sameness: the poses are distinctive, while the colors are fairly uniform, and the same corporate logo is stamped across them all—“Compliments of Star-Kist Foods, Inc.” Knowles’s suggestion of official sponsorship by the leading tuna brand StarKist was fraudulent, but she came much closer than one might expect. While teaching at CalArts, a student filmmaker told her that his father was the president of StarKist Foods, and his uncle was the manager of StarKist in California. Through this student, Knowles managed to get a complimentary crate of cans of tuna for another realization of *The Identical Lunch* at the University of California, Irvine."
@@ -7345,8 +7345,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "*Unidentified Woman Performs The Identical Lunch*"
     date: "1969, realized 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1969-01-01"
+    year_filter: [ "1969", "1973" ]
     medium: "screenprint with hand additions"
     location: ""
     extended_caption: "Alison Knowles made these photo-silkscreen portraits in the early 1970s based on a series of Polaroids she had taken of her friends and audience members performing [*The Identical Lunch*](/image-index/479/) at the New Year’s Eve Flux-Feast at the Fluxhouse Cooperative in SoHo in 1969. Knowles recalled in a 2008 interview with the art historian Jessica Santone, “I got a shower curtain and I isolated a little space in the corner of the room and then I invited particular people to come and I served them a lunch. I had a toaster in there, and I’d mixed up the tuna fish and I had the lettuce. They’d sit down and eat the lunch there and I’d take a Polaroid of them eating and then they could talk to me about whatever” (Alison Knowles, in discussion with Jessica Lynne Santone, 22 October 2008, in Jessica Lynne Santone, “Circulating the Event: The Social Life of Performance Documentation, 1965–1975” [PhD diss., McGill University, 2010], 102). Overall, the portraits strike a balance between individual difference and sameness: the poses are distinctive, while the colors are fairly uniform, and the same corporate logo is stamped across them all—“Compliments of Star-Kist Foods, Inc.” Knowles’s suggestion of official sponsorship by the leading tuna brand StarKist was fraudulent, but she came much closer than one might expect. While teaching at CalArts, a student filmmaker told her that his father was the president of StarKist Foods, and his uncle was the manager of StarKist in California. Through this student, Knowles managed to get a complimentary crate of cans of tuna for another realization of *The Identical Lunch* at the University of California, Irvine."
@@ -7360,8 +7360,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "*Shigeko Kubota Performs The Identical Lunch*"
     date: "1969, realized 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1969-01-01"
+    year_filter: [ "1969", "1973" ]
     medium: "screenprint with hand additions"
     location: ""
     extended_caption: "Alison Knowles made these photo-silkscreen portraits in the early 1970s based on a series of Polaroids she had taken of her friends and audience members performing [*The Identical Lunch*](/image-index/479/) at the New Year’s Eve Flux-Feast at the Fluxhouse Cooperative in SoHo in 1969. Knowles recalled in a 2008 interview with the art historian Jessica Santone, “I got a shower curtain and I isolated a little space in the corner of the room and then I invited particular people to come and I served them a lunch. I had a toaster in there, and I’d mixed up the tuna fish and I had the lettuce. They’d sit down and eat the lunch there and I’d take a Polaroid of them eating and then they could talk to me about whatever” (Alison Knowles, in discussion with Jessica Lynne Santone, 22 October 2008, in Jessica Lynne Santone, “Circulating the Event: The Social Life of Performance Documentation, 1965–1975” [PhD diss., McGill University, 2010], 102). Overall, the portraits strike a balance between individual difference and sameness: the poses are distinctive, while the colors are fairly uniform, and the same corporate logo is stamped across them all—“Compliments of Star-Kist Foods, Inc.” Knowles’s suggestion of official sponsorship by the leading tuna brand StarKist was fraudulent, but she came much closer than one might expect. While teaching at CalArts, a student filmmaker told her that his father was the president of StarKist Foods, and his uncle was the manager of StarKist in California. Through this student, Knowles managed to get a complimentary crate of cans of tuna for another realization of *The Identical Lunch* at the University of California, Irvine."
@@ -7375,8 +7375,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "*Anne Brazeau Performs The Identical Lunch*"
     date: "1969, realized 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1969-01-01"
+    year_filter: [ "1969", "1973" ]
     medium: "screenprint with hand additions"
     location: ""
     extended_caption: "Alison Knowles made these photo-silkscreen portraits in the early 1970s based on a series of Polaroids she had taken of her friends and audience members performing [*The Identical Lunch*](/image-index/479/) at the New Year’s Eve Flux-Feast at the Fluxhouse Cooperative in SoHo in 1969. Knowles recalled in a 2008 interview with the art historian Jessica Santone, “I got a shower curtain and I isolated a little space in the corner of the room and then I invited particular people to come and I served them a lunch. I had a toaster in there, and I’d mixed up the tuna fish and I had the lettuce. They’d sit down and eat the lunch there and I’d take a Polaroid of them eating and then they could talk to me about whatever” (Alison Knowles, in discussion with Jessica Lynne Santone, 22 October 2008, in Jessica Lynne Santone, “Circulating the Event: The Social Life of Performance Documentation, 1965–1975” [PhD diss., McGill University, 2010], 102). Overall, the portraits strike a balance between individual difference and sameness: the poses are distinctive, while the colors are fairly uniform, and the same corporate logo is stamped across them all—“Compliments of Star-Kist Foods, Inc.” Knowles’s suggestion of official sponsorship by the leading tuna brand StarKist was fraudulent, but she came much closer than one might expect. While teaching at CalArts, a student filmmaker told her that his father was the president of StarKist Foods, and his uncle was the manager of StarKist in California. Through this student, Knowles managed to get a complimentary crate of cans of tuna for another realization of *The Identical Lunch* at the University of California, Irvine."
@@ -7390,8 +7390,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "Letter from Alison Knowles to Jean Brown"
     date: "5 August ca. 1970s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1970-08-05"
+    year_filter: [ "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979" ]
     date_end: 31 5 August ca. 1970s
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 28, folder 36"
@@ -7421,8 +7421,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)", "Pauline Oliveros (American, 1932–2016)" ]
     title: "*Postcard Theatre*"
     date: "ca. 1970s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1970-01-01"
+    year_filter: [ "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979" ]
     medium: "offset"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 28, folder 36"
     extended_caption: "In the 1970s, Alison Knowles collaborated with the important experimental composer and self-identified lesbian Pauline Oliveros on the feminist *Postcard Theatre.* In the examples here, the most famous composers of Western concert music—all male—are boldly dismissed as lowly, laboring women (“a two-penny harlot,” “a Black Irish washerwoman,” “a mother,” “dishpan hands”). Photographs of Pauline Oliveros as a swaggering girl with a dagger and Knowles as a surly baby, as well as of Knowles’s young daughters absorbed in their own playing, ironically assert the existence (past and future) of women composers despite systemic gender discrimination."
@@ -7466,8 +7466,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "*Bean Sequences* booklet"
     date: "ca. 1981"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1981-01-01"
+    year_filter: [ "1981" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 28, folder 37"
     extended_caption: ""
@@ -7616,8 +7616,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "Letter from Alison Knowles to [Oscar] Emmett Williams"
     date: "April ca. 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-04-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 55, folder 14"
     extended_caption: ""
@@ -7631,8 +7631,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "Letter from Alison Knowles to [Oscar] Emmett Williams"
     date: "n.d. (ca. 1963)"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 55, folder 14"
     extended_caption: "In this letter to Emmett Williams, Alison Knowles describes an early work, [*BLINK*](/image-index/505/) (1963), that demonstrates the force and impossibility of “the identical,” for which she, George Brecht, and Robert Watts created “10 perfectly identical paintings. . . . Each of us is doing a strip 6” wide, on an 18” square. The idea of this is something like an anti-gallery thing, anti-painting too. . . . These paintings could be easily duplicated for anyone at 10 or 15 bucks apiece. Since they are scrupulously identical, all the gallery has, Ferus or 3rd rail or Kornblee or what have you, is one of a few examples. It sort of undermines the whole gallery prestige thing entirely.” Here Knowles indicates that her exploration of “the identical” is at the same time a critique of the commodification of art. In this letter Knowles also offers a vivid description of the performances she saw at the YAM Festival. Her tepid appraisal of Allan Kaprow’s *Tree* (1963), “one of his large scale vaguely allegorical things,” hints at a future divide between those artists who identified with Fluxus and those who identified with “happenings.”"
@@ -7646,8 +7646,8 @@ object_list:
     maker: [ "Alison Knowles (American, b. 1933)" ]
     title: "Letter from Alison Knowles to [Oscar] Emmett Williams"
     date: "n.d. [“Saturday night,” ca. 1963]"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 55, folder 14"
     extended_caption: "In this letter to Emmett Williams, Alison Knowles describes her experience of performing a series of Fluxus scores, as well as her observations of the audience’s responses, from “unruly and tittering” to quiet and calm. She also describes an early project, called the *Scissor Bros. Warehouse Sale* (1963), that demonstrates the force and impossibility of “the identical,” for which she, George Brecht, and Robert Watts created “fifty identical paintings all baring, bearing? [*sic*] the same print in a variety of colors and sizes.”"
@@ -7676,8 +7676,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Recipe for Rum Coconut"
     date: "ca. 1960s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969" ]
     medium: "typed index card"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 99, folder 2"
     extended_caption: "At a time when mainstream restaurants serving international foods were relatively uncommon, David Tudor shared an enthusiasm for cooking international cuisines with John Cage. In a 1987 interview with Peter Dickinson, Tudor compared cooking Indian food to the transformations of mentality required by Cage’s chance-derived scores. During the 1960s, when short, typewritten event scores became a salient mode of experimentation, Tudor’s recipes appear remarkably score-like, in a way that echoes [Knowles’s focus on everyday food preparation](/image-index/479/) as material for performances."
@@ -7691,8 +7691,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Recipe for Milk au Diable"
     date: "ca. 1960s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969" ]
     medium: "typed index card"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 99, folder 2"
     extended_caption: "At a time when mainstream restaurants serving international foods were relatively uncommon, David Tudor shared an enthusiasm for cooking international cuisines with John Cage. In a 1987 interview with Peter Dickinson, Tudor compared cooking Indian food to the transformations of mentality required by Cage’s chance-derived scores. During the 1960s, when short, typewritten event scores became a salient mode of experimentation, Tudor’s archive of recipes appear remarkably score-like, in a way that echoes [Knowles’s focus on everyday food preparation](/image-index/479/) as material for performances."
@@ -7796,8 +7796,8 @@ object_list:
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
     title: "List of participants in *Spatial Poem (Nos. 1–4)*"
     date: "ca. 1972"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1972-01-01"
+    year_filter: [ "1972" ]
     medium: "offset print"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 47, folder 3"
     extended_caption: "This flyer was mailed to [*Spatial Poem*](/image-index/530/#fig-530-g) (1965–75) participants after the completion of the fourth event, probably sometime in 1972. It shows that Mieko Shiomi was at the time based in Osaka and that George Maciunas had committed to designing “special issues” of each event’s collected reports. One hundred sixty-seven visual artists, musicians, composers, dancers, poets, filmmakers, gallerists, and other interlocutors are named. By listing out the names of all Shiomi’s collaborators up to that point, the document served to reflect the artist’s expansive international network back to itself."
@@ -7841,8 +7841,8 @@ object_list:
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
     title: "Promotional postcard for *Complete Works: Spatial Poem*"
     date: "ca. 1976"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1976-01-01"
+    year_filter: [ "1976" ]
     medium: "offset print"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 47, folder 3"
     extended_caption: ""
@@ -8051,8 +8051,8 @@ object_list:
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
     title: "Untitled"
     date: "ca. 1975"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1975-01-01"
+    year_filter: [ "1975" ]
     medium: "offset print"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 47, folder 3"
     extended_caption: ""
@@ -8066,8 +8066,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "This letter, probably from late 1963 or early 1964, is among the first letters exchanged between Mieko Shiomi and leading Fluxus organizer George Maciunas. Shiomi’s letter indicates that she initially experienced difficulties organizing a visit to New York, although she ultimately departed Japan in summer 1964 to make a yearlong trip. The letter attests to perceived differences between Fluxus circles in the United States and Japan, as Shiomi offers that Maciunas may “find in Japan FLUXUS people less individualism an[d] ego.”"
@@ -8081,8 +8081,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "fall 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-09-01"
+    year_filter: [ "1965" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "Mieko Shiomi wrote this letter to George Maciunas after returning to Japan after her year in New York. She reports on a Fluxus week of exhibitions and performances organized in September 1965 in Tokyo. Shiomi also weighs in on Maciunas’s growing conflict with Takahisa Kosugi, Nam June Paik, and Charlotte Moorman over their independent event organizing, particularly Moorman’s Avant-Garde Festival series, which Maciunas felt to be in competition with his Fluxus efforts. Shiomi advocates a nonhierarchical and expansive notion of collective avant-garde membership, since, as she explains, “our pieces contain almost endless possibilityies [*sic*] of performance.”"
@@ -8096,8 +8096,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-01-01"
+    year_filter: [ "1965" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8111,8 +8111,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: 1965-01-01""
+    year_filter: [ "1965" ]
     medium: "photocopy of typewritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "This letter, written to George Maciunas sometime in late 1965 after Mieko Shiomi had returned to Japan, shows that Shiomi was already busy crafting the object edition for [*Spatial Poem No. 1 (Word Event)*](/image-index/525/) (1965), a corkboard map dotted with paper flags printed with the text of participants’ reports. In Japan, Shiomi could not find the same supplies with which she had begun the project in New York. Shiomi’s mention of Maciunas’s performance of [*Spatial Poem No. 2 (Direction Event)*](/image-index/519/) (1965) was reported as follows: “George Maciunas was spinning himself on a office chair very rapidly in the elevator which was going up, thus facing all directions and moving upward in New York.” This letter, like many others in the [Archive section of chapter 10](/10/#archive), also chronicles Shiomi’s efforts to help Maciunas get an antique samurai sword from his personal collection repaired in Japan."
@@ -8141,8 +8141,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "In this letter, Mieko Shiomi responds to George Maciunas’s proposed design for the object edition of [*Spatial Poem No. 2 (Direction Event)*](/image-index/519/) (1965). She expresses misgivings about his expressive design choices, writing, “I’d like to show the people’s direction as transparently and exactly as possible. I’m afraid that too strong power of design’s image can weaken the contents.”"
@@ -8156,8 +8156,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas, with annotations by Maciunas"
     date: "ca. 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966" ]
     medium: "photocopy of handwritten and typewritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "This letter indicates that Mieko Shiomi invited George Maciunas’s editorial assistance in finalizing the language of some of her [scores for *Spatial Poem*](/image-index/530/#fig-530-g) (1965–75). The annotations on her typewritten text are his."
@@ -8186,8 +8186,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8201,8 +8201,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966" ]
     medium: "photocopy of typewritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8216,8 +8216,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "This letter critically responds to George Maciunas’s 1965 historical diagram and manifesto-like statement, *Fluxus (Its Historical Development and Relationship to Avant-Garde Movements)*. It stands as Mieko Shiomi’s most explicit rebuke to Maciunas about his delimited vision and “rough and autocratic” manner in organizing Fluxus publications and events, which she warns may lead to “social suicide.” Citing the historical example of André Breton’s role in the demise of French Surrealism, she advocates a vision of Fluxus success in which “many artists have to be spontaneously co-operative having the same aim and desire”—a model that in many ways corresponds to the structure of her [*Spatial Poem* series](/image-index/530/)  (1965–75)."
@@ -8231,8 +8231,8 @@ object_list:
     maker: 
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1968"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1968-01-01"
+    year_filter: [ "1968" ]
     medium: "handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "Following the completion of [*Spatial Poem No. 3 (Falling Event)*](/image-index/527/), Mieko Shiomi sent George Maciunas a list of additional contributors who had been incorporated into the project by the time [*Spatial Poem No. 4 (Shadow Event)*](/image-index/530/#fig-530-g) launched. The letter also includes mention of the Massachusetts-based collector of Dada and Surrealist ephemera Jean Brown, who recognized the importance of Fluxus among other contemporaneous neo-avant-garde tendencies and was beginning to collect works directly from artists. "
@@ -8246,8 +8246,8 @@ object_list:
     maker: 
     title: "Postcard from Mieko Shiomi to George Maciunas"
     date: "ca. 1968"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1968-01-01"
+    year_filter: [ "1968" ]
     medium: "handwritten text on a postcard"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8261,8 +8261,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1968"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1968-01-01"
+    year_filter: [ "1968" ]
     medium: "photocopy of typewritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8276,8 +8276,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1971"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1971-01-01"
+    year_filter: [ "1971" ]
     medium: "handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8306,8 +8306,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1972-01-01"
+    year_filter: [ "1972" ]
     medium: "photocopy of handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8321,8 +8321,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1972-01-01"
+    year_filter: [ "1972" ]
     medium: "handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: "This letter is one of [many that detail Mieko Shiomi’s efforts to help George Maciunas have a katana samurai sword repaired in Japan](/image-index/549/). Interestingly, Shiomi’s account of the difficulty of this task reveals details about geopolitical relationships between the United States and Japan, as well as Shiomi’s newfound limitations since becoming a wife and mother. She reports that it is forbidden to send money from Japan to the United States, while lamenting that “my situation is like a prisoner in house.” Developing artistic collaborations that could be realized by mail established a lifeline that sustained her artistic practice during this difficult period in her life."
@@ -8336,8 +8336,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1972-01-01"
+    year_filter: [ "1972" ]
     medium: "handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8351,8 +8351,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1972-01-01"
+    year_filter: [ "1972" ]
     medium: "handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8381,8 +8381,8 @@ object_list:
     maker: 
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1974"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1974-01-01"
+    year_filter: [ "1974" ]
     medium: "handwritten text on paper"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 30"
     extended_caption: ""
@@ -8418,8 +8418,8 @@ object_list:
     maker: 
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, NY"
     date: "summer 1958"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-06-01"
+    year_filter: [ "1958" ]
     medium: ""
     location: ""
     extended_caption: "John Cage taught experimental composition at the New School for Social Research [multiple times between 1956 and 1959](/image-index/556/). This photograph shows the catalytic Summer 1958 cohort, which included Jackson Mac Low (fourth from left), Allan Kaprow (in the back row, second from right), George Brecht (in the back row, right, elbow visible), Al Hansen (center, with tie), and Dick Higgins. Each week, Cage asked the students to compose a score in response to a prompt, which might specify readymade “instruments” (like radios) or chance procedures (like tossing coins). The students would perform these rough-and-ready scores with Cage during class and debate their qualities. In this photograph, students realize an Al Hansen assignment using a portable collection of noisy toys—whirler tube, cat-meow, and bicycle bell, among others. Kaprow took Cage’s course more often than anyone else and affirmed several times that he created what he considered to be his first happenings (avant la lettre) as assignments for Cage’s class."
@@ -8433,8 +8433,8 @@ object_list:
     maker: 
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-06-01"
+    year_filter: [ "1958" ]
     medium: ""
     location: ""
     extended_caption: "John Cage taught experimental composition at the New School for Social Research [multiple times between 1956 and 1959](/image-index/556/). This photograph shows the catalytic Summer 1958 cohort, which included Allan Kaprow (seated, right), George Brecht (seated, left), Al Hansen (standing), Jackson Mac Low, and Dick Higgins. Each week Cage asked the students to compose a score in response to a prompt, which might specify readymade “instruments” (like radios) or chance procedures (like tossing coins). The students would perform these rough-and-ready scores with Cage during class and debate their qualities. In this photograph, Kaprow and Brecht talk to Hansen about realizing his score for a portable collection of noisy toys—whirler tube, cat-meow, and bicycle bell, among others. Kaprow took Cage’s course more often than anyone else and affirmed several times that he created what he considered to be his first happenings (avant la lettre) as assignments for this class."
@@ -8448,8 +8448,8 @@ object_list:
     maker: 
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-06-01"
+    year_filter: [ "1958" ]
     medium: ""
     location: ""
     extended_caption: "John Cage taught experimental composition at the New School for Social Research [multiple times between 1956 and 1959](/image-index/556/). This photograph shows Jackson Mac Low (right) and Dick Higgins (left), two students in the catalytic Summer 1958 cohort, which also included Allan Kaprow, George Brecht, and Al Hansen. Each week, Cage asked the students to compose a score in response to a prompt, which might specify readymade “instruments” (like radios) or chance procedures (like tossing coins). The students would perform these rough-and-ready scores with Cage during class and debate their qualities. In this photograph, Higgins and Mac Low play a toy battleship and whirler tube, respectively, in a realization of an Al Hansen composition created in response to one of Cage’s assignments."
@@ -8463,8 +8463,8 @@ object_list:
     maker: 
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-06-01"
+    year_filter: [ "1958" ]
     medium: ""
     location: ""
     extended_caption: "John Cage taught experimental composition at the New School for Social Research [multiple times between 1956 and 1959](/image-index/556/). This course was famously “open to those with or without musical training” (as stated in the course catalog). Indeed, some of the key students enrolled in the Summer 1958 session were known primarily as visual artists and had limited musical training (e.g., Allan Kaprow, and especially Al Hansen). But it is also true that other regular members of the class—including Carol Galente (left) and Stephen Addiss (right)—came to the course with classical musical training and more conventional musical taste. In this photograph, Mac Low (center) plays a drum that was part of a large collection of traditional, albeit non-Western, percussion instruments kept in a closet in Cage’s classroom. The tensions and disagreements that arose from the students’ differing disciplinary backgrounds and philosophies helped to create a charged atmosphere conducive to risk-taking. There could be a measure of difference among the teachers’ perspectives, too: When Cage was on tour, Morton Feldman, Earle Brown, and Richard Maxfield would substitute for him, bringing their distinctive ideas about composition to the students."
@@ -8478,8 +8478,8 @@ object_list:
     maker: 
     title: "John Cage leading his experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-06-01"
+    year_filter: [ "1958" ]
     medium: ""
     location: ""
     extended_caption: "John Cage taught experimental composition at the New School for Social Research [multiple times between 1956 and 1959](/image-index/556/). While the course was very much hands-on, it also included much philosophical discussion, and some lectures by Cage, as the course description promised “a full exposition of the contemporary music scene in the light of the work of Anton Webern, and present developments in music for magnetic tape.” Many former students recall the transformative effect of Cage’s charismatic presence, and especially his rare combination of rigor and playfulness—seen here in Cage’s delighted smile. George Brecht was hardly alone when he explained in 1967 that Cage’s outsize influence on his students “came as much from Cage the person as from his works or ideas.”"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1406,7 +1406,7 @@ object_list:
     title: "Liner notes for *Indeterminacy* recording"
     date: "1959; reissued 1992"
     date_sort: "1959-01-01"
-    year_filter: [ "1959" ]
+    year_filter: [ "1959", "1992" ]
     medium: ""
     location: ""
     extended_caption: ""
@@ -1900,8 +1900,8 @@ object_list:
     maker: 
     title: "David Tudor’s press materials"
     date: "1959?"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-01-01"
+    year_filter: [ "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 52, folder 7; and box 81, folder 14"
     extended_caption: ""
@@ -1960,8 +1960,8 @@ object_list:
     maker: 
     title: "David Tudor performing John Cage’s *Water Music* at Darmstadt"
     date: "1958, or possibly 1956"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1956-01-01"
+    year_filter: [ "1956", "1958" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 158"
     extended_caption: ""
@@ -2410,8 +2410,8 @@ object_list:
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
     title: "Loose score sheets for Sylvano Bussotti’s *Pièces de chair II*"
     date: "1958–60"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-01-01"
+    year_filter: [ "1958", "1959", "1960" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 174, folder 3"
     extended_caption: "David Tudor’s copy of Sylvano Bussotti’s score contains spare but important pencil annotations that reveal key choices of his in developing realizations of the score."
@@ -2500,8 +2500,8 @@ object_list:
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
     title: "Performance notes for Sylvano Bussotti’s *Pièces de chair II*"
     date: "1958–59"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-01-01"
+    year_filter: [ "1958", "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 174, folder 3"
     extended_caption: "These are the broader performance notes for the entirety of *Pièces de chair II*. Page one shows the way the larger work contains *Piano Pieces for David Tudor* nested inside the larger cycle. They are distributed throughout the cycle, placed out of order, while also being prominently featured: *No. 5* opens the cycle, and *No. 4* serves as the finale."
@@ -2650,8 +2650,8 @@ object_list:
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
     title: "Miscellaneous scores by Sylvano Bussotti sent to David Tudor"
     date: "1959(?)"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-01-01"
+    year_filter: [ "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 51, folder 8"
     extended_caption: ""
@@ -2950,8 +2950,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Lecture notes on David Tudor’s performance practice as a pianist during the late 1950s and early ’60s"
     date: "early 1960s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961", "1962", "1963", "1964" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 107, folder 10"
     extended_caption: "This is a set of lecture notes David Tudor wrote for a lecture in Darmstadt, likely in 1961. They demonstrate his trajectory as a pianist toward the use of realizations during the 1950s. In addition to describing a great number of specific scores and their demands on the performer, Tudor describes a philosophy that abjures “muscular rhythm” in favor of the possibility of “irregular rhythm” that is based in the “bloodstream” and “body feeling” that can be elicited in sight-reading techniques and customized notations “when visual and aural impressions overlap.” In his lecture, Tudor notes that this latter idea is indebted to Morton Feldman’s approach to composition."
@@ -2965,8 +2965,8 @@ object_list:
     maker: [ "Manfred Leve (German, 1936–2012)" ]
     title: "David Tudor performing with gloves"
     date: "ca. 1959"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-01-01"
+    year_filter: [ "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 159"
     extended_caption: ""
@@ -3236,8 +3236,8 @@ object_list:
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     title: "Assorted text scores"
     date: "1961–62"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-01"
+    year_filter: [ "1961", "1962" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 39, folder 33"
     extended_caption: "These text scores are closer to the emerging genre of event scores insofar as they minimize specifications of time and residues of musical notation."
@@ -3281,8 +3281,8 @@ object_list:
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     title: "*Variations for Double-Bass*"
     date: "1961, rev. 1962"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-01"
+    year_filter: [ "1961", "1962" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 39, folder 33"
     extended_caption: "First performed by Benjamin Patterson himself, these variations take the performer and their bass as the “theme”; the “variations” are a series of event scores. The number of sounds and the duration of each variation are left up to the bassist."
@@ -3311,8 +3311,8 @@ object_list:
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     title: "Notes on art"
     date: "1960s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 41, folder 2"
     extended_caption: "This is a notebook of Benjamin Patterson’s notes on art recorded during the 1960s. His reflections, though often fragmentary, are deeply philosophical and speculative, ranging on topics from communication and social cybernetics, to process philosophy, musical form, freedom vs. determinacy, internal vs. external, time and temporality, politics, the role of the artist in society, and ideas about audience reception. The notebook also includes sketches of event scores, poetic experiments, drawings, and addresses."
@@ -3326,8 +3326,8 @@ object_list:
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     title: "Poems"
     date: "1960s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 39, folder 33"
     extended_caption: ""
@@ -3824,8 +3824,8 @@ object_list:
     maker: [ "Simone Forti (American, b. 1935)" ]
     title: "Performances of Simone Forti’s *Huddle* and *Slant Board*, from the event *An Evening of Dance Constructions,* Museum of Contemporary Art, Los Angeles, CA"
     date: "1961; performed 2004; film released 2009"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "2004-01-01"
+    year_filter: [ "1961", "2004", "2009" ]
     medium: ""
     location: ""
     extended_caption: "This performance was directed by Simone Forti, and produced by Julie Martin and Pooh Kaye. ¶ Forti's [“dance constructions” for *Huddle* and *Slant Board*](/image-index/238/?region=4100,1100,1600,1100#fig-238-bg) can be found in the Getty Research Institute’s unique copy of *An Anthology of Chance Operations* (1962), published by Jackson Mac Low and George Maciunas and edited by La Monte Young."
@@ -3869,8 +3869,8 @@ object_list:
     maker: 
     title: "Flyer for “Three Evenings of Picnic and Electronic Music by Richard Maxfield,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "28–30 April 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-04-28"
+    year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 38, folder 16"
     extended_caption: "From December 1960 to June 1961, La Monte Young and Yoko Ono hosted an experimental concert series in Ono’s loft at 112 Chambers Street in downtown Manhattan. Each concert focused on an individual artist. Featured artists included Terry Jennings, Toshi Ichiyanagi, Henry Flynt, Joseph Byrd, Jackson Mac Low, Richard Maxfield, La Monte Young, Simone Forti, and Robert Morris, with many more concerts planned but never executed. The performances and installations presented at this modest, cold-water flat served as a catalyst for the emerging trend of intermedia that would soon be documented in [*An Anthology*](/image-index/238/#fig-238-a). The concerts were attended by multiple generations of avant-garde artists and patrons, including John Cage, Marcel Duchamp, Peggy Guggenheim, Jasper Johns, and Robert Rauschenberg. Rigorous experimentalism was valued above all, as Young’s motto, printed on most of the series’ programs stated: “THE PURPOSE OF THIS SERIES IS NOT ENTERTAINMENT.”"
@@ -3884,8 +3884,8 @@ object_list:
     maker: 
     title: "Flyer for “Compositions by La Monte Young,” part of the concert series organized by Yoko Ono and Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "19–20 May 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-05-19"
+    year_filter: [ "1961" ]
     date_end: 31 19–20 May 1961
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 38, folder 16"
@@ -3900,8 +3900,8 @@ object_list:
     maker: 
     title: "Program for “Compositions by La Monte Young,” part of the concert series organized by Yoko Ono and Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "19–20 May 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-05-19"
+    year_filter: [ "1961" ]
     date_end: 31 19–20 May 1961
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 38, folder 16"
@@ -3931,8 +3931,8 @@ object_list:
     maker: 
     title: "List of the Judson Dance Theater’s dance concerts, 1961–66"
     date: "ca. 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 79, folder 11"
     extended_caption: ""
@@ -3961,8 +3961,8 @@ object_list:
     maker: 
     title: "Program for a performance by the group Theatre of Eternal Music, with La Monte Young, John Cale, Marian Zazeela, and Tony Conrad"
     date: "ca.1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-01-01"
+    year_filter: [ "1965" ]
     medium: ""
     location: "Getty Research Institute, Robert Watts Papers, 2006.M.27, box 58, folder 20"
     extended_caption: ""
@@ -4021,8 +4021,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "Artist index cards"
     date: "1961–64"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-01"
+    year_filter: [ "1961", "1962", "1963", "1964" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 41"
     extended_caption: "George Maciunas, lead organizer of Fluxus, was an obsessive administrator who used index cards to collect information about the artists with whom he worked—including biographies, transcriptions of performance scores, and notes about his correspondence with them."
@@ -4081,8 +4081,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "Letters from George Maciunas to Dick Higgins"
     date: "18 January 1962 and February 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-01-18"
+    year_filter: [ "1962", "1963" ]
     medium: "photocopy of original correspondence"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 5"
     extended_caption: "These letters show George Maciunas’s frantic attempts to orchestrate and control Fluxus events from afar during his time working as a graphic designer at a U.S. military base in Wiesbaden, West Germany. He discusses sending and receiving scores by mail, exploiting his access to inexpensive Army Post Office rates, and Dick Higgins’s efforts to organize a Fluxus festival in Stockholm in March 1963, which, against Maciunas’s wishes, ultimately did take place."
@@ -4096,8 +4096,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "Plans for Fluxus publications and a new music festival"
     date: "ca. 1962"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-01-01"
+    year_filter: [ "1962" ]
     medium: "photocopy of original print"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 31, folder 5"
     extended_caption: ""
@@ -4111,8 +4111,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "“Conditions for Performing Fluxus Published Compositions, Films & Tapes”"
     date: "ca. 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-01-01"
+    year_filter: [ "1965" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 39, folder 32"
     extended_caption: "These conditions for Fluxus performance were written up by George Maciunas and distributed to his network following [the first European Fluxus concert tour](/image-index/356/) in 1963–64. The document proposes legislating how the “Fluxus” name can be used and how fees will be collected whenever affiliated artists’ works are performed. Maciunas’s intent was to support his artist peers while solidifying and protecting the collective aims of Fluxus, but his conditions were immediately controversial and provoked a harsh backlash. The proposal to centralize, trademark, and monetize Fluxus activities was seen as overly controlling and against the spirit of the movement. The conditions were never adopted."
@@ -4141,8 +4141,8 @@ object_list:
     maker: 
     title: "Program for *Poetry, Music, and Theatre Works: Jackson Mac Low*, the fifth concert in the series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "8–9 April 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-04-08"
+    year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 32, folder 6"
     extended_caption: "Although Jackson Mac Low had academic training in Western musical composition, his artist self-image, at least initially, was that of a poet. He submitted poems relentlessly to mainstream U.S. poetry publications before and during the McCarthy Red Scare era, apparently without realizing that he was being blacklisted for his radical political views. This program for Yoko Ono and La Monte Young’s loft series celebrates Mac Low as a composer of performance works that, if not strictly musical in nature, are intended to be performed in a “concert” setting. While many of the other composers featured in this concert series became well-known members of the 1960s avant-garde, Mac Low’s contributions have been less frequently recognized, falling through the cracks that separate monodisciplinary narratives in art history, literary studies, and performance studies."
@@ -4171,8 +4171,8 @@ object_list:
     maker: [ "Remy Charlip (American, 1929–2012)" ]
     title: "Flyer for recitals by David Tudor at the Living Theatre, New York, NY"
     date: "March–April 1960"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-03-01"
+    year_filter: [ "1960" ]
     date_end: 31 March– April 1960
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 72, folder 7"
@@ -4247,8 +4247,8 @@ object_list:
     maker: 
     title: "Flyer for “Music by Toshi Ichiyanagi,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "7–8 January 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-07"
+    year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 73, folder 1"
     extended_caption: "From December 1960 to June 1961, La Monte Young and Yoko Ono hosted an experimental concert series in Ono’s loft at 112 Chambers Street in downtown Manhattan. Each concert focused on an individual artist. Featured artists included Terry Jennings, Toshi Ichiyanagi, Henry Flynt, Joseph Byrd, Jackson Mac Low, Richard Maxfield, La Monte Young, Simone Forti, and Robert Morris, with many more concerts planned but never executed. The performances and installations presented at this modest, cold-water flat served as a catalyst for the emerging trend of intermedia that would soon be documented in [*An Anthology*](/image-index/238/#fig-238-a). The concerts were attended by multiple generations of avant-garde artists and patrons, including John Cage, Marcel Duchamp, Peggy Guggenheim, Jasper Johns, and Robert Rauschenberg. Rigorous experimentalism was valued above all, as Young’s motto, printed on most of the series’ programs stated: “THE PURPOSE OF THIS SERIES IS NOT ENTERTAINMENT.”"
@@ -4262,8 +4262,8 @@ object_list:
     maker: 
     title: "Program for “Music by Toshi Ichiyanagi,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "7–8 January 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-07"
+    year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 73, folder 1"
     extended_caption: "From December 1960 to June 1961, La Monte Young and Yoko Ono hosted an experimental concert series in Ono’s loft at 112 Chambers Street in downtown Manhattan. Each concert focused on an individual artist. Featured artists included Terry Jennings, Toshi Ichiyanagi, Henry Flynt, Joseph Byrd, Jackson Mac Low, Richard Maxfield, La Monte Young, Simone Forti, and Robert Morris, with many more concerts planned but never executed. The performances and installations presented at this modest, cold-water flat served as a catalyst for the emerging trend of intermedia that would soon be documented in [*An Anthology*](/image-index/238/#fig-238-a). The concerts were attended by multiple generations of avant-garde artists and patrons, including John Cage, Marcel Duchamp, Peggy Guggenheim, Jasper Johns, and Robert Rauschenberg. Rigorous experimentalism was valued above all, as Young’s motto, printed on most of the series’ programs stated: “THE PURPOSE OF THIS SERIES IS NOT ENTERTAINMENT.”"
@@ -4307,8 +4307,8 @@ object_list:
     maker: [ "Ray Johnson (American, 1927–95)" ]
     title: "Collage created from a flyer designed by Remy Charlip for recitals by David Tudor at the Living Theatre, New York, NY, plus an envelope"
     date: "ca. 1960"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 72, folder 7"
     extended_caption: ""
@@ -4338,8 +4338,8 @@ object_list:
     maker: 
     title: "Miniature mock-up for *An Anthology of Chance Operations* with handwritten notes, probably by Jackson Mac Low, George Maciunas, and La Monte Young"
     date: "ca. 1962"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-01-01"
+    year_filter: [ "1962" ]
     medium: ""
     location: "UC San Diego Special Collections and Archives, Jackson Mac Low Papers, MSS 180"
     extended_caption: "This miniature mock-up of [*An Anthology*](/image-index/238/) shows how Jackson Mac Low, La Monte Young, and George Maciunas approached the basic design of the publication, ordering page spreads and choosing different stocks of paper, samples of which are stapled to individual leaves throughout."
@@ -4458,8 +4458,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "Chart of artistic movements and media including optic, acoustic, kinetic, and semantic/symbolic arts, mailed by George Maciunas to Jackson Mac Low"
     date: "ca. 1961–62"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-01-01"
+    year_filter: [ "1961", "1962" ]
     medium: ""
     location: "UC San Diego Special Collections and Archives, Jackson Mac Low Papers, MSS 180"
     extended_caption: "During the final stages of [*An Anthology*](/image-index/238/)’s design and assembly, George Maciunas corresponded with Jackson Mac Low and La Monte Young from Wiesbaden, West Germany, where he worked as a graphic designer for the U.S. military. In a series of letters written between late 1961 and early 1963, we see Maciunas offering multiple design ideas for *An Anthology*’s cover and binding, including several that would deliberately create a difficult reading experience, and pleading for copies to be sent to him for distribution in Europe. (Mac Low and Young ultimately chose a conventional perfect-bound paperback format whose cover features the book’s title repeated tightly in black against a vibrant red background.) These letters also show that Maciunas was already busy collecting materials for a new series of anthologies that would be published under the name of Fluxus and include many of the same artists brought together in *An Anthology*. "
@@ -4503,8 +4503,8 @@ object_list:
     maker: [ "La Monte Young (American, b. 1935)" ]
     title: "Letter from La Monte Young to David Tudor"
     date: "1960–61"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 61, folder 2; and box 14, folders 4 and 9"
     extended_caption: ""
@@ -4518,8 +4518,8 @@ object_list:
     maker: [ "La Monte Young (American, b. 1935)" ]
     title: "Letter from La Monte Young to David Tudor"
     date: "1960–61"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960", "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 61, folder 2; and box 14, folders 4 and 9"
     extended_caption: ""
@@ -4548,8 +4548,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "A Realization of Earle Brown’s *December 1952*"
     date: "1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 170, folder 2"
     extended_caption: "David Tudor’s realization of [*December 1952*](/image-index/301/) is, as was typical for him, fairly straightforward and involved careful measurements. For his sound events, he chose a variety of tone clusters of varied sizes, dynamics, and durations. Though nothing in Earle Brown’s score precludes a dense or fast realization, many interpreters see and hear in it a relatively sparse and impersonal landscape of isolated sounds."
@@ -4623,8 +4623,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Notes for a realization of Toshi Ichiyanagi’s *Music for Piano No. 4 (for David Tudor)*"
     date: "ca. late 1960"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-07-01"
+    year_filter: [ "1960" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 10, folder 7"
     extended_caption: "David Tudor, as usual, takes his freedoms seriously. His realization involves a detailed plan that entails the use of a number of materials and auxiliary percussion."
@@ -4773,8 +4773,8 @@ object_list:
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "September, ca. 1962"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-09-01"
+    year_filter: [ "1962" ]
     date_end: 30 September, ca. 1962
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 54, folder 7"
@@ -5082,8 +5082,8 @@ object_list:
     maker: [ "Anthony Matejczyk" ]
     title: "“Music for Our Time: Gurgles and Growls,” review of a David Tudor and Alvin Lucier performance of works by Alvin Lucier, Toshi Ichiyanagi, and John Cage, *Boston Herald*"
     date: "ca. February 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-02-01"
+    year_filter: [ "1966" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, boxes 63, folder 1"
     extended_caption: ""
@@ -5227,8 +5227,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Drip Music (Drip Event)*"
     date: "1959–62"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-01-01"
+    year_filter: [ "1959", "1960", "1961" ]
     medium: "offset print"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 127 (contained within the compendium *Water Yam*)"
     extended_caption: "Among George Brecht’s most well-known compositions, *Drip Music (Drip Event)* (1959–62) bears many characteristics that typify the artist’s event scores, and the way it is dated suggests Brecht honed the text gradually and carefully over the course of his most intensive years of score writing. In 1960, Brecht began to call his works “events” as opposed to “music,” though this score retains both titles. Its first line immediately opens the possibility of the work’s performance to a multiplicity of realizations, by either a solo performer or a group, and even by nonhuman actors. (All possibilities would be experimented with by Fluxus artists, as [chapter 6’s Archive section](/06/#archive) shows.) Notably, the language avoids both an imperative tone as well as outwardly naming the agent of the action. Instead, it describes in a rather passive way the existence of the phenomenon of water dripping, leaving the words “source” and “vessel” open to interpretation. The even more ambiguous “second version” included in the score’s text might be written for more advanced readers familiar with Brecht’s work, such as the virtuoso listener for whom, as the artist described in his 1959 notebook, “all sound may be music” (George Brecht, notebook page ca. late July 1959, from Cage’s course in Experimental Composition, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 3 [Cologne: Walther König, 1991], 123). At this time Brecht also wrote the similar yet slightly more elaborate score *Comb Music (Comb Event)* (1959–62)."
@@ -5242,8 +5242,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "Event score included in *Water Yam*"
     date: "1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: "offset print"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 127"
     extended_caption: ""
@@ -5302,8 +5302,8 @@ object_list:
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     title: "*Drip Music* (1959), from the album *George Brecht/Ben Patterson: Drip Music/370 Flies*, Alga Marghen (record label), Milan, Italy, 2002"
     date: "recorded 2002"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "2002-01-01"
+    year_filter: [ "2002" ]
     medium: "digital audio, 38:07"
     location: ""
     extended_caption: "This audio recording of Benjamin Patterson’s realization of George Brecht’s [*Drip Music (Drip Event)*](/image-index/346/) (1959–62) was made in Paris following a [public performance in June 2002 at La Ménagerie de Verre](/image-index/352/), and with the same setup. Without the photographic documentation, it would be hard to imagine the nature of the instrument used to create the hollow, almost wooden sounds captured here. Still, the pacing of the sonic attacks strongly evokes the irregular rhythms of dripping water, and as the drips slow down, the nature of the electronic manipulation of the sounds becomes more noticeable. Patterson’s version of *Drip Music* is more meditative and at times even more demanding for the audience to behold than other realizations included in chapter 6, which typically last only a few minutes. The [accompanying photographs documenting the recording session](/image-index/383/) show Patterson taking on the role of both director and audience for the piece, as he listens closely to the slow unfolding of drips over the course of almost forty minutes."
@@ -5527,8 +5527,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Drip Music*"
     date: "ca. 1970"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1970-01-01"
+    year_filter: [ "1970" ]
     medium: "photograph"
     location: ""
     extended_caption: "George Brecht often made sculptural realizations of his event scores, as in this iteration, an adjustable dripping faucet designed for the garden of German collectors Wolfgang and Ute Feelisch. Brecht once remarked, “Once in a while I would make an object first and then make a card later . . . . I don’t feel very much one way of the other since every object is an event anyway and every event has [an] object-like quality” (Michael Nyman, “An Interview with George Brecht” [1976], in Henry Martin, *An Introduction to George Brecht’s Book of the Tumbler on Fire* [Milan: Multhipla, 1978], 106)."
@@ -5559,8 +5559,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "*Ekstra Bladet/Politiken*, 1992 reprint by Edition Hundertmark"
     date: "early 1963; reprinted in 1992"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963", "1992" ]
     medium: "offset print of original newspaper collage"
     location: ""
     extended_caption: "In early 1963, George Maciunas made this two-sided broadsheet collage by gathering together reviews of the [first Fluxus concerts in Wiesbaden](/image-index/356/), [Düsseldorf](/image-index/361/), and [Copenhagen](/image-index/359/). The two sheets were designed to be glued together to make one long page that could be sent through the mail as a rolled-up scroll. Most of the clippings came from German and Danish newspapers, but some articles prove that news of the Fluxus events reached readers as far as Italy and Austria. (Mastheads from regional papers like the *Telegraph-Herald* in Dubuque, Iowa, may have been added by Maciunas for humorous effect.) The madcap layout, reminiscent of Dada and Surrealist publications of the early twentieth century, is characteristic of the Fluxus newspapers Maciunas would publish under varying iterations of the name *cc V TRE*.  ¶ The layout also amplifies and revels in the many bemused accounts of reviewers, which accord with the kind of language one finds in reviews of performances of John Cage’s radical music. To point to one example, the Associated Press piece penned by Richard O’Regan cheekily recounts of the Wiesbaden festival, “This wasn’t a barroom brawl. It wasn’t a political rally. It was a concert of ‘very new music and anti-music’ in Wiesbaden’s dignified art museum.” O’Regan’s account was published in the American military newspaper [*Stars and Stripes*](/image-index/230/), which had a Darmstadt office out of which Fluxus artist and participating performer Emmett Williams worked as features editor."
@@ -5574,8 +5574,8 @@ object_list:
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
     title: "Letter from George Maciunas to George Brecht"
     date: "ca. January 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 30, folder 31"
     extended_caption: "This extraordinary letter from George Maciunas to George Brecht, sent in early 1963, provides a highly detailed record of the artists’ collaborative design process and their ongoing deliberations over the intellectual significance of Brecht’s events and their transcription as event scores. ¶ In the <a class='ref' data-figure-id='fig-369-a' data-annotation-ids=''>first part</a> of the letter, Maciunas draws a diagram that imagines the relation between optical and acoustical elements in a work of art, possibly in response to Brecht’s remark in another letter that, “a minimum condition for my work . . . is a lack of distinction between ‘optical,’ ‘acoustical’ and other such categories” (Brecht to Maciunas, early 1963, Hanns Sohm Archive, Staatsgalerie Stuttgart). To this, Maciunas adds the dimension of artificial versus concrete (or “reality”). With reference to scores by Brecht that had been performed during the European Fluxus concert tour—namely *Piano Piece* (1962; “a vase of flowers on(to) a piano”) and *Word Event* (1961; “EXIT”)—Maciunas considers the fine line between art and non art, between deliberately formed and ready-made gestures, and between conceptual and perceptual experience that the scores traverse, ultimately comparing their operation to Zen Buddhist philosophy. ¶ In <a class='ref' data-figure-id='fig-369-b' data-annotation-ids=''>section two</a> of this letter, Maciunas discusses the disposition of [*Water Yam*](/image-index/348/) (1963) in terms of future editions and copyright and introduces the idea of a renewable subscription model or “perpetual” box. He mentions Fluxus newsletter no. 5, which he wrote and distributed to the Fluxus network in January 1963, as “a draft for a written agreement.” In that controversial newsletter, Maciunas proposed that affiliate artists assign to Fluxus the copyright and exclusive publication rights for their works in order to present a “common front” for Fluxus activities and to achieve financial security (with individual artists retaining 80 percent of profits from the sale of their work). In section three, Maciunas reports on his research into international locations amenable to his dream of developing a self-sustaining, permanent Fluxus commune. ¶ In the <a class='ref' data-figure-id='fig-369-c' data-annotation-ids=''>fourth section</a> of this letter, Maciunas attaches samples of paper for the printing of the *Water Yam* event score cards for Brecht to choose from. An added note in Brecht’s handwriting shows his first choice of white for all cards. ¶ In two <a class='ref' data-figure-id='fig-369-e' data-annotation-ids=''>pages appended</a> to this letter, Maciunas returns to the topic of the design for *Water Yam*, addressing card size and sketching out playful box and label design ideas for Brecht’s consideration."
@@ -5680,8 +5680,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Incidental Music*, event score sent to David Tudor"
     date: "summer 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-06-01"
+    year_filter: [ "1961" ]
     medium: "spirit duplicating"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 5, folder 23"
     extended_caption: "This copy of George Brecht’s event score *Incidental Music* (1961) reached the hands of David Tudor, who [performed the piece in September 1961 at the Internationale Ferienkurse für Neue Musik](/image-index/382/) in Darmstadt, Germany. A July 1961 letter from Brecht to Tudor makes apparent that the work was added to the program without Brecht’s knowledge, and that his scores had a more rapid and wide distribution than anticipated. Brecht wrote, “Two people now have told me that a piano piece of mine is on the Darmstadt program. Hence curiosity; I don’t know of any such score in circulation. Have you any information on this?” Once Brecht’s confusion had been cleared, he wrote to advise Tudor, “Children’s alphabet blocks are convenient for 2. Disposition of the photograph is an aspect of 3” (Letters from Brecht to Tudor, 11 July and 11 August 1961, Getty Research Institute, David Tudor Papers, 980039, box 51, folder 8)."
@@ -5695,8 +5695,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Handwritten and typed transcriptions of George Brecht event scores"
     date: "ca. 1962–63"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-01-01"
+    year_filter: [ "1962", "1963" ]
     medium: "pen and typewriter ink on paper"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 5, folder 23"
     extended_caption: "These annotated transcriptions of George Brecht scores found in David Tudor’s archive indicate that Tudor was in the habit of writing out experimental notations in his own way even when not entirely necessary. Perhaps Tudor made these transcriptions in order to combine multiple event score cards into fewer pages, or to make copies of scores already in his possession. In any case, Tudor privileges the textual content of the pieces even as Brecht was very mindful of his scores’ graphic layout, particularly the amount of white space surrounding his text."
@@ -5725,8 +5725,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Motor Vehicle Sundown (Event)*, event score sent to David Tudor"
     date: "spring/summer 1960"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-03-01"
+    year_filter: [ "1960" ]
     medium: "offset print"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 5, folder 23"
     extended_caption: ""
@@ -5740,8 +5740,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Three Aqueous Events*, event score sent to David Tudor"
     date: "summer 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-06-01"
+    year_filter: [ "1961" ]
     medium: "offset print and ink on paper"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 5, folder 23"
     extended_caption: ""
@@ -5755,8 +5755,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Three Chair Events*, event score sent to David Tudor"
     date: "spring 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-03-01"
+    year_filter: [ "1961" ]
     medium: "offset print"
     location: "Getty Research Institute, David Tudor Papers, 980039, box 5, folder 23"
     extended_caption: ""
@@ -5815,8 +5815,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "Notebook page, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 2 (Cologne: Walther König, 1991), 64–66"
     date: "ca. December 1958"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1958-12-01"
+    year_filter: [ "1958" ]
     date_end: 31 ca. December 1958
     medium: ""
     location: "Getty Research Institute, item 92-B17341, vol. 2"
@@ -5876,8 +5876,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "Notebook page, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 3 (Cologne: Walther König, 1991), 123"
     date: "ca. late July 1959"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-07-15"
+    year_filter: [ "1959" ]
     date_end: 31 ca. late July 1959
     medium: ""
     location: "Getty Research Institute, item 92-B17341, vol. 3"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -5903,8 +5903,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "Notebook page, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 3 (Cologne: Walther König, 1991), 125"
     date: "ca. late July 1959"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-07-15"
+    year_filter: [ "1959" ]
     date_end: 31 ca. late July 1959
     medium: ""
     location: "Getty Research Institute, item 92-B17341, vol. 3"
@@ -6064,8 +6064,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Mallard Milk*, event score sent to David Tudor"
     date: "summer 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-06-01"
+    year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 5, folder 23"
     extended_caption: ""
@@ -6079,8 +6079,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)", "Robert Watts (American, 1923–88)" ]
     title: "*Lantern Extract*, envelope and seventeen scores sent to M. C. Richards"
     date: "late 1962"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1962-07-01"
+    year_filter: [ "1962" ]
     medium: ""
     location: "Getty Research Institute, Mary Caroline Richards Papers, 960036, box 6, folder 6"
     extended_caption: "This selection of scores was sent by George Brecht and Robert Watts to the poet and potter M. C. Richards, whom the artists met through David Tudor. Brecht and Watts, who first met in 1957, sent these mailings to a broad swath of their artistic community as the first gesture in their multipart YAM Festival, which culminated in a month-long series of performances and exhibitions in the New York area in May 1963. Watts’s score cards can be distinguished from Brecht’s irregularly formatted compositions in black-and-white by their consistent business card–like dimensions and colored paper. Whereas the [Fluxus concert series unfolding simultaneously in Europe](/image-index/356/) approached such scores as prompts for activities to be performed publicly in concert hall settings, Brecht and Watts’s mailing accords with what might better be described as a conceptual or mail art practice, as well as Brecht’s notion of the scores as “little enlightenments I wanted to communicate to my friends who would know what to do with them” (George Brecht, “The Origin of ‘Events’” [August 1970], in *Happening and Fluxus*, ed. Harald Szeemann and Hanns Sohm [Cologne: Kölnischer Kunstverein, 1970], n.p.)."
@@ -6094,8 +6094,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "Letters from George Brecht to Jill Johnston"
     date: "ca. 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: "letter"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 3, folder 31"
     extended_caption: "These two letters from George Brecht to Jill Johnston, the dance and theatre critic for *The Village Voice* who wrote about Brecht’s work on several occasions, document Brecht’s struggles to make Johnston understand his practice and its goals. ¶ In the first two-page letter, Brecht’s discussion of “choosing” reflects upon the lasting significance of Marcel Duchamp’s readymade—a quotidian object chosen by the artist and reframed as a work of art. Foundational to Brecht’s practice, the notion of the readymade was extended to include the sorts of readymade actions captured in his event scores (i.e., “EXIT”). Brecht is particularly interested in the passivity of noticing or perceiving an event as opposed to actively performing or arranging one, a subtle yet important distinction that recalls [George Maciunas’s letter to Brecht about perceptual versus conceptual experience](/image-index/369/) also reproduced in this publication. Brecht writes, “There is neither action nor inaction, but simply an event occurring spontaneously, unwilled, out of nowhere, nowhen.” ¶ The first letter also provides a catalog of Brecht’s art historical interests: Erik Satie, Kurt Schwitters, Duchamp, the Zen philosopher and calligrapher Hakuin Ekaku, and Man Ray. His mention of a “center” reflects his [ongoing conversation](/image-index/403/) with the poet and potter M. C. Richards, author of the 1964 book *Centering in Pottery, Poetry, and the Person*. Finally, the enigmatic date provided—“day of last council”—is keyed to tne poet (and drummer for the Velvet Underground) Angus MacLise’s [*Year*](/image-index/416/) (1962), a poetic alternative calendar that Brecht frequently used to date his personal correspondence. ¶ In the second one-page letter, Brecht zeroes in on his relationship to chance operations and their pioneering use by Duchamp and John Cage. He explains that he is not committed indefinitely to chance operations but appreciates them as a means to de-subjectify the work of art and (perhaps impossibly) eliminate the determining role of the artist. “Beyond a certain point,” he writes, “the work is not ‘done’ (by anyone), but simply occurs.”"
@@ -6124,8 +6124,8 @@ object_list:
     maker: 
     title: "Interactive map of locations relevant to the creation and distribution of Jackson Mac Low’s postcard scores"
     date: "spring 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-03-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: ""
     extended_caption: ""
@@ -6231,8 +6231,8 @@ object_list:
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
     title: "Letter from Jackson Mac Low to John Cage in Stony Point, NY"
     date: "ca. 10 February 1955"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1955-02-10"
+    year_filter: [ "1955" ]
     medium: ""
     location: "Getty Research Institute, Mary Caroline Richards Papers, 960036, box 42, folder 2"
     extended_caption: ""
@@ -6246,8 +6246,8 @@ object_list:
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
     title: "Letter from Jackson Mac Low to David Tudor in Stony Point, NY"
     date: "ca. 10 February 1955"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1955-02-10"
+    year_filter: [ "1955" ]
     medium: ""
     location: "Getty Research Institute, Mary Caroline Richards Papers, 960036, box 42, folder 2"
     extended_caption: ""
@@ -6261,8 +6261,8 @@ object_list:
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
     title: "Letter from Jackson Mac Low to M. C. Richards in Stony Point, NY"
     date: "ca. 10 February 1955"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1955-02-10"
+    year_filter: [ "1955" ]
     medium: ""
     location: "Getty Research Institute, Mary Caroline Richards Papers, 960036, box 42, folder 2"
     extended_caption: ""
@@ -6396,8 +6396,8 @@ object_list:
     maker: [ "Barbara Moore (American)", "Jon Hendricks (American, b. 1940)" ]
     title: "Inventory and price list for Jackson Mac Low items for sale from Backworks"
     date: "summer 1977"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1977-06-01"
+    year_filter: [ "1977" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 32, folder 5"
     extended_caption: "Backworks was a New York–based publishing and bookselling operation co-led by Barbara Moore and Jon Hendricks that focused on avant-garde publications and ephemera."
@@ -6501,8 +6501,8 @@ object_list:
     maker: 
     title: "Program for “Jackson Mac Low with Merce Cunningham and Dance Company” at Cunningham Studio at Westbeth, New York, NY"
     date: "16–17 February 1974"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1974-02-16"
+    year_filter: [ "1974" ]
     medium: ""
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 32, folder 6"
     extended_caption: ""
@@ -6606,8 +6606,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notebook sketches related to *We Shall Run* (1963)"
     date: "ca. 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 1, folder 5"
     extended_caption: ""
@@ -6636,8 +6636,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Performance of *We Shall Run* (1963) at Bennington College, Bennington, VT"
     date: "ca. early 1980s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1980-01-01"
+    year_filter: [ "1980", "1981", "1982", "1983", "1984" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 108, item V41"
     extended_caption: "In *We Shall Run* (1963), dancers in everyday street clothes jog in groups across the stage, splintering off into smaller or larger groups over the course of the performance. At times, all the dancers join together in one forward motion; at others, they split into groups of equal size or smaller pods (of one to three people) splinter away, crossing the others’ paths and eventually rejoining the larger group. From time to time, a sole dancer weaves through an existing group in motion. There is no narrative context, just the music of the “Tuba mirum” passage from Hector Berlioz’s *Requiem*, which provides a surprising contrast to the generic affect and unchanging pace of the dancers’ collective movement. This performance of *We Shall Run* was also [captured by Babette Mangolte in photographs](/image-index/447/)."
@@ -6681,8 +6681,8 @@ object_list:
     maker: ""
     title: "Interview with Charles Atlas (excerpt from Atlas’s *Rainer Variations*)"
     date: "2001–2"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "2001-01-01"
+    year_filter: [ "2001", "2002" ]
     medium: "video, 65:34"
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 116, item V85a-b"
     extended_caption: ""
@@ -6696,8 +6696,8 @@ object_list:
     maker: ""
     title: "Yvonne Rainer attempting to teach *Trio A* to Martha Graham, impersonated by Richard Move in drag (excerpt from Charles Atlas’s *Rainer Variations*)"
     date: "2001–2"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "2001-01-01"
+    year_filter: [ "2001", "2002" ]
     medium: "video, 64:03"
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 116, item V86a-b"
     extended_caption: "This excerpt from video artist Charles Atlas’s longer work *Rainer Variations* (other excerpts of which are included in [chapter 8](/08/)) shows a bemused Yvonne Rainer attempting to teach [*Trio A*](/image-index/440/) (1966) to famed modern dance artist Martha Graham, who is played by the choreographer Richard Move in drag. This dynamic collaboration between Rainer, Atlas, and Move brings together Rainer’s interest in both dance and the moving image as well as melodrama and humor, queer aesthetics and critique, dance history, and the practice of revisiting and remixing her past works. Describing Atlas’s *Rainer Variations* as a “faux Rainer portrait,” Rainer has remarked: “At play here is a skepticism about the conventions of the documentary form that purports to reveal the ‘real’ artist who ultimately remains a persona or crafty impersonator of her own idealized self-image” (liner notes to Charles Atlas, *Rainer Variations*, DVD, Electronic Arts Intermix, New York, 2002, n.p.)."
@@ -6711,8 +6711,8 @@ object_list:
     maker: ""
     title: "Interview with Kathleen Chalfant (excerpt from Charles Atlas’s *Rainer Variations*)"
     date: "2001–2"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "2001-01-01"
+    year_filter: [ "2001", "2002" ]
     medium: "video, 72:00"
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 116, item V87a-b"
     extended_caption: ""
@@ -6786,8 +6786,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notebook page related to *Watering Place* (ca. 1960)"
     date: "ca. 1960"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 1, folder 2"
     extended_caption: ""
@@ -6801,8 +6801,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Untitled notebook pages on performer versus audience"
     date: "ca. 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-01-01"
+    year_filter: [ "1963" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 1, folder 5"
     extended_caption: ""
@@ -6816,8 +6816,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Notes, draft program, and cue sheets related to *The Mind Is a Muscle* (1966–68), including *Trio A*, *Trio B*, and *Mat*"
     date: "ca. 1966–68"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966", "1967", "1968" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 1, folder 10"
     extended_caption: "These ephemera are related to Yvonne Rainer’s multipart work [*The Mind Is a Muscle*](/image-index/456/), of which [*Trio A*](/image-index/440/) is a part. They show the extent to which, of all the notation styles Rainer experimented with, straightforward linguistic description remained one of her favored methods."
@@ -6831,8 +6831,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Pages from the score for *Watering Place* (ca. 1960)"
     date: "ca. 1960"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1960-01-01"
+    year_filter: [ "1960" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 21, folder 14"
     extended_caption: "These scores for *Watering Place* were developed in Robert Dunn’s dance composition course held at the Merce Cunningham Studio. Each of the pages was drawn for a different performer but based on [a common pattern of stage movement](/image-index/448/) defined by concentric circles intersected by diagonal lines. The scores show Rainer experimenting with compositional indeterminacy derived from the dancers’ choices as well as unpredictably timed encounters with their fellow performers."
@@ -6861,8 +6861,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Graphic scores related to *Film*, from *The Mind Is a Muscle* (1966–68)"
     date: "ca. 1966–68"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966", "1967", "1968" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 2"
     extended_caption: ""
@@ -6876,8 +6876,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "Graphic scores related to *Trio B*, from *The Mind is a Muscle* (1966–68)"
     date: "ca. 1966–68"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-01"
+    year_filter: [ "1966", "1967", "1968" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 3"
     extended_caption: ""
@@ -6891,8 +6891,8 @@ object_list:
     maker: 
     title: "Judson Dance Theater concert program for “A Dance Concert of Old and New Works by: David Gordon, Yvonne Rainer, Steve Paxton”"
     date: "10–12 January 1966"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1966-01-10"
+    year_filter: [ "1966" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 4"
     extended_caption: ""
@@ -6906,8 +6906,8 @@ object_list:
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     title: "*The Mind Is a Muscle* concert program, Anderson Theater, New York, NY"
     date: "11, 14, 15 April 1968"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1968-04-11"
+    year_filter: [ "1968" ]
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 4"
     extended_caption: "This program for a complete, evening-length presentation of [*The Mind Is a Muscle*](/image-index/456/) (1966–68) includes an important statement from Yvonne Rainer that addresses the seemingly disconnected relationship between her uninflected dance aesthetic and contemporary politics, in particular the traumatic spectacle of the Vietnam War. “This statement is not an apology,” she writes. “It is a reflection of a state of mind that reacts with horror and disbelief upon seeing a Vietnamese shot dead on TV—not solely at the sight of death, however, but at the fact that the TV can be shut off afterwards as after a bad Western. My body remains the enduring reality.” In 1970, Rainer would reimagine her [*Trio A* as a protest dance](/image-index/445/) in the context of Faith Ringgold, Jean Toche and Jon Hendricks’s *The People's Flag Show*."
@@ -6981,8 +6981,8 @@ object_list:
     maker: [ "Jill Johnston (American, 1929–2010)" ]
     title: "“Yvonne Rainer: I” and “Yvonne Rainer: II,” *The Village Voice*"
     date: "23 May 1963 and 6 June 1963"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1963-05-23"
+    year_filter: [ "1963" ]
     date_end: 31 23 May 1963 and 6 June 1963
     medium: ""
     location: "Getty Research Institute, Yvonne Rainer Papers, 2006.M.24, box 22, folder 4"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -97,8 +97,8 @@ object_list:
     maker: [ "Kurt Schwitters (German, 1887–1948)" ]
     title: "*Ursonate*, in *Merz* 24 (Hanover, 1932)"
     date: "1922–32"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1922-01-01"
+    year_filter: [ "1922", "1923", "1924", "1925", "1926", "1927", "1928", "1929", "1930", "1931", "1932" ]
     medium: ""
     location: ""
     extended_caption: "Kurt Schwitters’s *Ursonate* is a forty-minute phonetic poem and is representative of Dadaism. It was first published in the magazine *Merz* in 1932. Schwitters coined the term *Merz* based on an advertisement he saw in *Kommerzbank*. The concept is present in all of Schwitters’s artistic works. "
@@ -352,8 +352,8 @@ object_list:
     maker: [ "Morton Feldman (American, 1926–87)" ]
     title: "Transparency sheet with graph guidelines"
     date: "early 1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 26B"
     extended_caption: "This was likely an aid to making an early graph score, such as Morton Feldman’s [*Projection 1*](/image-index/046/)."
@@ -472,8 +472,8 @@ object_list:
     maker: 
     title: "“Merce Cunningham of New York”"
     date: "August 1953?"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1953-08-01"
+    year_filter: [ "1953" ]
     date_end: 31 August 1953?
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 62, folder 5"
@@ -683,8 +683,8 @@ object_list:
     maker: [ "Morton Feldman (American, 1926–87)" ]
     title: "Embryonic graph score, likely for *Projection 1*"
     date: "early 1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 30"
     extended_caption: "This early graph score by Morton Feldman was likely an early sketch for his first completed graph score, [*Projection 1*](/image-index/046/)."
@@ -728,8 +728,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Realization of Morton Feldman’s *Intersection +* (Sketches of Numbered Boxes)"
     date: "ca. 1953"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1953-01-01"
+    year_filter: [ "1953" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 25"
     extended_caption: ""
@@ -743,8 +743,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Realization of Morton Feldman’s *Intersection +* (Sketches of Clusters)"
     date: "ca. 1953"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1953-01-01"
+    year_filter: [ "1953" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 25"
     extended_caption: ""
@@ -758,8 +758,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Realization of Morton Feldman’s *Intersection +* (Quarter-note Realization)"
     date: "ca. 1953"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1953-01-01"
+    year_filter: [ "1953" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 25"
     extended_caption: ""
@@ -803,8 +803,8 @@ object_list:
     maker: [ "Morton Feldman (American, 1926–87)" ]
     title: "*Intersection 2*"
     date: "ca. 1951–52"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1951-01-01"
+    year_filter: [ "1951", "1952" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 26"
     extended_caption: "This is an early graph score by Morton Feldman similar in style to *Intersection 3*, although with more silence, a slower tempo, and fewer notes."
@@ -818,8 +818,8 @@ object_list:
     maker: [ "David Tudor (American, 1926–96)" ]
     title: "Realization of Morton Feldman’s *Intersection 2*"
     date: "early 1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 9, folder 26"
     extended_caption: "This is likely David Tudor’s first attempt at a realization of any indeterminate score. It was notated in a bound book of staff paper. For his realization of John Cage’s scores in the mid- to late 1950s, Tudor would eventually come to use short, loose staff paper sheets on relatively thicker cardstock. These realizations on cardstock could be reshuffled and bound in various orders."
@@ -848,8 +848,8 @@ object_list:
     maker: 
     title: "David Tudor performing in Spain"
     date: "1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 158"
     extended_caption: ""
@@ -863,8 +863,8 @@ object_list:
     maker: 
     title: "David Tudor as a young man at the piano"
     date: "1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 158"
     extended_caption: ""
@@ -878,8 +878,8 @@ object_list:
     maker: 
     title: "David Tudor as young man at the piano"
     date: "1950s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1950-01-01"
+    year_filter: [ "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 158"
     extended_caption: ""
@@ -893,8 +893,8 @@ object_list:
     maker: 
     title: "Christian Wolff, Earle Brown, John Cage, David Tudor, and Morton Feldman at the Capitol Records building in New York"
     date: "ca. 1953"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1953-01-01"
+    year_filter: [ "1953" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 166"
     extended_caption: "An iconic photograph of David Tudor with the New York School of composers."
@@ -908,8 +908,8 @@ object_list:
     maker: [ "John Cage (American, 1912–92)" ]
     title: "David Tudor’s copy of John Cage’s *Solo for Piano*, from *Concert for Piano and Orchestra*"
     date: "1957–58"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1957-01-01"
+    year_filter: [ "1957", "1958" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 176, folders 1–2"
     extended_caption: "This is David Tudor’s copy of John Cage’s *Solo for Piano*, copied out in Cage’s trademark penmanship, which features capital letters with exaggerated serifs. Marveling at the score can be an overwhelming experience; the notation asks us to puzzle over an exceedingly complicated set of rules and procedures. Following the title page, Cage’s score includes two introductory pages of lettered directions that serve as a key for deciphering the lettered graphs that follow. Each graph, paired with its corresponding instructions, thus functions as its own self-contained mini score. Globally, there is a playful sense of inventiveness and creativity to the visual language of Cage’s graphs. In fact, spurred by the encouragement of Jasper Johns and Robert Rauschenberg, the score for *Concert for Piano and Orchestra* was exhibited at a midtown gallery in New York just prior to the Town Hall premiere, and it was thus Cage’s first score to be [publicly appreciated as visual art](/image-index/095/). Though many of the *Concert*’s graphs are quite indeterminate, leaving many of the compositional process up to the performer, Tudor’s performances turned out a certain consistent impression; reviewers attested that the *Solo for Piano* sounded “mixed-up,” and that it evoked “anarchy,” a sense of psychosis, or even a “jungle.”"
@@ -923,8 +923,8 @@ object_list:
     maker: [ "John Cage (American, 1912–92)" ]
     title: "David Tudor’s copy of the conductor’s part for *Concert for Piano and Orchestra*"
     date: "1957–58"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1957-01-01"
+    year_filter: [ "1957", "1958" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 7, folder 2"
     extended_caption: ""
@@ -938,8 +938,8 @@ object_list:
     maker: [ "John Cage (American, 1912–92)" ]
     title: "Bassoon and baritone saxophone parts from *Concert for Piano and Orchestra*"
     date: "1957–58"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1957-01-01"
+    year_filter: [ "1957", "1958" ]
     medium: ""
     location: ""
     extended_caption: "The thirteen orchestral parts for the *Concert* are essentially solo instrument parts with single attacks and a wide range of extended techniques. Many of them were created in conversation with individual performers who introduced John Cage to various nontraditional possibilities of each instrument. The performances of these parts displeased Cage. As the recordings featured here attest, these performers often played loudly and frequently competed with David Tudor. Some players strayed from the score with what Cage later described as “unprofessional” and “foolish” playing. Some responsibility for the difficulties seemed to lie with Cage; indeed, he was unaccustomed to writing for an orchestra, and the piece’s lack of traditional orchestration was inevitably going to lead to the different sounds stepping on one another’s toes. We might speculate: Did Cage realize he needed a stronger (dare we say “intentional” or “expressive”) hand in sculpting the result? Whatever the case, the difficulties exemplify a recurring problem Cage had when he was not working with trusted collaborators like Tudor. For his book *Experimentalism Otherwise* (2011) Benjamin Piekut interviewed the original performers from the New York Philharmonic who participated in the slightly later, and even more controversial, premiere of *Atlas Eclipticalis* (1964) under the direction of Leonard Bernstein."
@@ -953,8 +953,8 @@ object_list:
     maker: [ "John Cage (American, 1912–92)" ]
     title: "Trumpet part from *Concert for Piano and Orchestra*"
     date: "1957–58"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1957-01-01"
+    year_filter: [ "1957", "1958" ]
     medium: ""
     location: ""
     extended_caption: ""
@@ -1405,8 +1405,8 @@ object_list:
     maker: [ "John Cage (American, 1912–92)", "Richard Kostelanetz (b. 1940)" ]
     title: "Liner notes for *Indeterminacy* recording"
     date: "1959; reissued 1992"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1959-01-01"
+    year_filter: [ "1959" ]
     medium: ""
     location: ""
     extended_caption: ""

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -8508,8 +8508,8 @@ object_list:
     maker: [ "George Brecht (American, 1926–2008)" ]
     title: "*Three Telephone Events*, from *Water Yam* (1963)"
     date: "spring 1961"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1961-03-01`"
+    year_filter: [ "1961" ]
     medium: "offset printed on card stock"
     location: "Getty Research Institute, Jean Brown Papers, 890164, box 127"
     extended_caption: ""
@@ -8659,8 +8659,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Printed program for *Routine*, presented at the Portland Center for the Visual Arts, Portland, Oregon"
     date: "29 November– 2 December 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1973-11-29"
+    year_filter: [ "1973" ]
     date_end: 31 29 November– 2 December 1973
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 24, folder 9"
@@ -8735,8 +8735,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Review of using *7 Kinds of Sympathy* videotape as score"
     date: "ca. 1976"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1976-01-01"
+    year_filter: [ "1976" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 74, C28"
     extended_caption: "Participants: Peter Kirby, Allan Kaprow, Nancy Buchanan, Sylvia and Jerry Simpson, and Vaughn Rachel at Video Transitions, Hollywood."
@@ -8780,8 +8780,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "*Throat and Cough Piece*"
     date: "1957–58"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1957-01-01"
+    year_filter: [ "1957", "1958" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 4, folder 13"
     extended_caption: "Kaprow composed this score while he was attending John Cage’s experimental composition course at the New School for Social Research. By taxonomizing and then scoring behavior that is ordinarily involuntary (coughing, clearing one’s throat), Kaprow explores Cage’s ideal of non-intentionality in a comic mode. Cage himself could sometimes be a subtly comic performer, making use of puns and deadpan in some of his performance lectures."
@@ -8870,8 +8870,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Handwritten page of notes for *Soap*"
     date: "fall 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-09-01"
+    year_filter: [ "1965" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 9, folder 6"
     extended_caption: "[*Soap*](/image-index/585/) was commissioned by Florida State University for the Eighteenth Annual Symposium at the Ringling Museum of Art, Sarasota, Florida, 1–4 February 1965. Kaprow lays out the form and meaning of the score for *Soap* in notes he may have used when introducing the happening to potential participants on 2 February."
@@ -8915,8 +8915,8 @@ object_list:
     maker: 
     title: "Letter from Robert Carter, a graduate student in painting at Florida State University, to Allan Kaprow"
     date: "ca. 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-01-01"
+    year_filter: [ "1965" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 9, folder 6"
     extended_caption: "Allan Kaprow’s [*Soap*](/image-index/585/) was commissioned by Florida State University for the Eighteenth Annual Symposium at the Ringling Museum of Art, Sarasota, Florida, 1–4 February 1965. In this score, Kaprow sets up an equivalence between natural and social cycles. In the mid-1960s Kaprow engaged with structural anthropology and the study of ritual, and in his [notes for the *Soap* briefing](/image-index/586/), he even went so far as to call it an “archaic purification rite,” seemingly without irony. But in asking student participants to urinate and bury one another in sand while naked, Kaprow violated fundamental taboos. As a result, [the happening was canceled](/image-index/588/). Nevertheless, graduate student Robert Carter decided to realize the score, and wrote this letter to Kaprow about his experience. Carter describes his performance in psychedelic terms, as comparable to taking a strong dose of peyote."
@@ -8945,8 +8945,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Program for Florida State University’s Eighteenth Annual Symposium, which included Kaprow’s *Soap*"
     date: "1–4 February 1965"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1965-02-01"
+    year_filter: [ "1965" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 9, folder 6"
     extended_caption: "In this conference program, interested participants—but “no onlookers”—are invited to meet Kaprow in the Ringling Museum’s courtyard on 2 February (the second day of the symposium) at 2 p.m. [The happening itself](/image-index/585/) was scheduled for various slots on the third and fourth of that month."
@@ -9155,8 +9155,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Production still from Allan Kaprow’s 16mm film of *Routine*"
     date: "29 November–2 December 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1973-11-29"
+    year_filter: [ "1973" ]
     date_end: 31 29 November–2 December 1973
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 24, folder 9"
@@ -9276,8 +9276,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "“How to Use these videotapes and booklets”"
     date: "ca. 1970s"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1970-01-01"
+    year_filter: [ "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 34, folder 10"
     extended_caption: "Allan Kaprow likely composed this text to accompany an exhibition of his videotapes and activity booklets. Here he explains how photographic media can be used to create something like “music scores,” or “notations which one or more persons can carry out” after looking at them. The “How to” of the title of this text is a nod to Kaprow’s irreverent idea that artists’ scores belong to the ordinary social world of educational films and product packaging."
@@ -9321,8 +9321,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Score for *Soap* in the form of a poster"
     date: "1964–65"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1964-01-01"
+    year_filter: [ "1964", "1965" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, series III, roll 2**"
     extended_caption: "Allan Kaprow painted this version of [the score for *Soap*](/image-index/585/) on brown butcher paper. He later used poster versions of scores as advertisements so they could be read at a distance."
@@ -9381,8 +9381,8 @@ object_list:
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     title: "Sketches for illustrations for the program for *Loss*"
     date: "ca. 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1973-01-01"
+    year_filter: [ "1973" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 20, folder 13"
     extended_caption: ""
@@ -9396,8 +9396,8 @@ object_list:
     maker: 
     title: "Allan Kaprow’s clipping of instructions for applying Bluboro™ powder"
     date: "ca. 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1973-01-01"
+    year_filter: [ "1973" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 20, folder 13"
     extended_caption: ""
@@ -9456,8 +9456,8 @@ object_list:
     maker: 
     title: "Contact sheet of photographs by Alvin Comiter, with Allan Kaprow’s notations"
     date: "ca. 1973"
-    date_sort: ""
-    year_filter: ""
+    date_sort: "1973-01-01"
+    year_filter: [ "1973" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 20, folder 13"
     extended_caption: "Alvin Comiter prepared this contact sheet in 1973 for Allan Kaprow to use later in [“Easy Activity”](/image-index/617/) (1975), a proto-activity booklet published in a book of art history essays. Comiter, who was trained in nuclear physics before he went to art school, graduated from the California Institute of the Arts in 1973, where Kaprow was a dean and professor (1969–74). Comiter also took the photographs that Kaprow would use in one of Kaprow's first official activity booklets, [*Routine*](/image-index/573/) (1975)."


### PR DESCRIPTION
Trying to make sure I'm doing this correctly....pull request going to third-pages branch and not main. 

This was straight forward, just a couple cases I wasn't 100% on: 

-id:  “092” date is 1959; reissued 1992. Would I include 1992 in the year filter as well? (I did add both) 
	-Same with id: “368” (added both)
-same situation: id “129”: date is 1958 or possibly 1956. Adding both to year range, and 1956 for date sort. 

-id “217” has a revision in the following year (included both)

-id “254”: date of composition, performance, and film all separate (included each in years). But date set is tough here. Going with year of performance. 

-id “484” and “487”: includes date and realized date. Included both in year range. 