### PR TITLE
Scores adding "people," first 100 objects

### DIFF
--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -463,7 +463,7 @@ object_list:
     old_id: "1.11d"
     maker: 
     people: [ "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
-    more_people: [ "Webern, Anton", "Boulez, Pierre", "Stockhausen, Karlheinz", "Wolff, Christian" ]
+    more_people: [ "Boulez, Pierre", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“WHRB Presents David Tudor, Pianist, & John Cage in a Program for ‘New’ Music for Piano at Harvard University”"
     date: "20 April 1956"
     date_sort: "1956-04-20"
@@ -667,8 +667,8 @@ object_list:
     id: "039"
     old_id: "1.12j"
     maker: 
-    people:  [ "Tudor, David", "Feldman, Morton", "Cage, John" ]
-    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Wolpe, Stefan" ]
+    people:  [ "Tudor, David", "Feldman, Morton", "Cage, John", "Wolff, Christian", "Boulez, Pierre", "Wolpe, Stefan" ]
+    more_people:
     title: "“Musical Events: Old Horizons,” *New Yorker*, 125–33"
     date: "8 May 1954"
     date_sort: "1954-05-08"
@@ -735,8 +735,8 @@ object_list:
     id: "043"
     old_id: "1.12o"
     maker: 
-    people: [ "Cage, John", "Tudor, David", "Brown, Earle", "Feldman, Morton" ]
-    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
+    people: [ "Cage, John", "Tudor, David", "Brown, Earle", "Feldman, Morton", "Wolff, Christian", "Stockhausen, Karlheinz", "Nilsson, Bo" ]
+    more_people:
     title: "“Mozart bevorzugte für das Spiel von Hausmusik. . . ,” *The Observer*"
     date: "15 December 1958"
     date_sort: "1958-12-15"
@@ -803,7 +803,7 @@ object_list:
     id: "047"
     old_id: "1.15a"
     maker: [ "Morton Feldman (American, 1926–87)" ]
-    people: [ "Feldman, Morton" ]
+    people: [ "Feldman, Morton", "Tudor, David" ]
     more_people: ""
     title: "*Intersection +*"
     date: "1953"
@@ -1007,8 +1007,8 @@ object_list:
     id: "059"
     old_id: "1.18"
     maker: 
-    people: [ "Brown, Earle", "Cage, John", "Feldman, Morton", "Tudor, David" ]
-    more_people: [ "Wolff, Christian" ]
+    people: [ "Brown, Earle", "Cage, John", "Feldman, Morton", "Tudor, David", "Wolff, Christian" ]
+    more_people: 
     title: "Christian Wolff, Earle Brown, John Cage, David Tudor, and Morton Feldman at the Capitol Records building in New York"
     date: "ca. 1953"
     date_sort: "1953-01-01"
@@ -1024,7 +1024,7 @@ object_list:
     id: "060"
     old_id: "2.01a"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "David Tudor’s copy of John Cage’s *Solo for Piano*, from *Concert for Piano and Orchestra*"
     date: "1957–58"
@@ -1041,7 +1041,7 @@ object_list:
     id: "061"
     old_id: "2.01b"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "David Tudor’s copy of the conductor’s part for *Concert for Piano and Orchestra*"
     date: "1957–58"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -871,7 +871,7 @@ object_list:
     id: "051"
     old_id: "1.15e"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (32nd-note Realization)"
     date: "n.d."
@@ -888,7 +888,7 @@ object_list:
     id: "052"
     old_id: "1.15f"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Alternative 32nd-note Realization)"
     date: "n.d."
@@ -922,7 +922,7 @@ object_list:
     id: "054"
     old_id: "1.16b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection 2*"
     date: "early 1950s"
@@ -939,7 +939,7 @@ object_list:
     id: "055"
     old_id: "1.17a"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor performing a work by John Cage in London"
     date: "1954"
@@ -956,7 +956,7 @@ object_list:
     id: "056"
     old_id: "1.17b"
     maker: 
-    people: ""
+    people: [ "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing in Spain"
     date: "1950s"
@@ -973,7 +973,7 @@ object_list:
     id: "057"
     old_id: "1.17c"
     maker: 
-    people: ""
+    people: [ "Tudor, David" ]
     more_people: ""
     title: "David Tudor as a young man at the piano"
     date: "1950s"
@@ -990,7 +990,7 @@ object_list:
     id: "058"
     old_id: "1.17d"
     maker: 
-    people: ""
+    people: [ "Tudor, David" ]
     more_people: ""
     title: "David Tudor as young man at the piano"
     date: "1950s"
@@ -1007,8 +1007,8 @@ object_list:
     id: "059"
     old_id: "1.18"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Brown, Earle", "Cage, John", "Feldman, Morton", "Tudor, David" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Christian Wolff, Earle Brown, John Cage, David Tudor, and Morton Feldman at the Capitol Records building in New York"
     date: "ca. 1953"
     date_sort: "1953-01-01"
@@ -1092,7 +1092,7 @@ object_list:
     id: "064"
     old_id: "2.02"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "First realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -1109,7 +1109,7 @@ object_list:
     id: "065"
     old_id: "2.03"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Supplementary score pages for the first realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -1126,7 +1126,7 @@ object_list:
     id: "066"
     old_id: "2.05"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Pencil draft of the second realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -1143,7 +1143,7 @@ object_list:
     id: "067"
     old_id: "2.06"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Final version of the second realization of John Cage’s *Solo for Piano* for the *Indeterminacy* recording (1959)"
     date: "1958"
@@ -1298,7 +1298,7 @@ object_list:
     id: "075"
     old_id: "2.07"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the first realization of John Cage’s *Concert for Piano and Orchestra* at Town Hall"
     date: "1958"
@@ -1315,7 +1315,7 @@ object_list:
     id: "076"
     old_id: "2.08"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Studio recording of the second realization of John Cage’s *Solo for Piano* for with Cage’s *Indeterminacy* stories"
     date: "1959"
@@ -1332,7 +1332,7 @@ object_list:
     id: "077"
     old_id: "2.09"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the first realization of John Cage’s *Concert for Piano and Orchestra* at Mills College"
     date: "1964"
@@ -1349,7 +1349,7 @@ object_list:
     id: "078"
     old_id: "2.10"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Studio recording of David Tudor performing *Concert for Piano and Orchestra*"
     date: "1993"
@@ -1366,7 +1366,7 @@ object_list:
     id: "079"
     old_id: "2.11"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Performance of the second realization of John Cage’s *Solo for Piano*"
     date: ""
@@ -1383,7 +1383,7 @@ object_list:
     id: "080"
     old_id: "2.12"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the *Solo for Piano* at the Philadelphia Museum of Art"
     date: "11 September 1982"
@@ -1400,7 +1400,7 @@ object_list:
     id: "081"
     old_id: "2.13a"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the *Solo for Piano* at the Almeida Theatre in London"
     date: "13 June 1986"
@@ -1417,7 +1417,7 @@ object_list:
     id: "082"
     old_id: "2.13b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor’s Sonorities for John Cage’s *Solo for Piano*"
     date: ""
@@ -1434,8 +1434,8 @@ object_list:
     id: "083"
     old_id: "2.14a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "Flyer for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1451,8 +1451,8 @@ object_list:
     id: "084"
     old_id: "2.14b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro", "Richards, Mary Caroline" ]
     title: "Press release for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -565,7 +565,7 @@ object_list:
     id: "033"
     old_id: "1.12d"
     maker: 
-    people: ""
+    people: [ "Cage, John" ]
     more_people: ""
     title: "“Cage to Perform ‘Abstract’ Music,” *Daily Illini*"
     date: "24 March 1953"
@@ -582,8 +582,8 @@ object_list:
     id: "034"
     old_id: "1.12e"
     maker: [ "Duffy Defibaugh" ]
-    people: [ "Defibaugh, Duffy" ]
-    more_people: ""
+    people: [ "Defibaugh, Duffy", "Cage, John", "Brown, Earle" ]
+    more_people: [ "Barron, Bebe and Louis", "Henry, Pierre" ]
     title: "“‘Magnetic Music’ Not Ready,” *Daily Illini*"
     date: "March 1953"
     date_sort: "1953-03-01"
@@ -599,8 +599,8 @@ object_list:
     id: "035"
     old_id: "1.12f"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Defibaugh, Duffy", "Cage, John", "Brown, Earle" ]
+    more_people: [ "Barron, Bebe and Louis", "Henry, Pierre" ]
     title: "Front page of the *Daily Illini*"
     date: "March 1953"
     date_sort: "1953-03-01"
@@ -616,8 +616,8 @@ object_list:
     id: "036"
     old_id: "1.12g"
     maker: [ "Peggy Glanville-Hicks" ]
-    people: [ "Glanville-Hicks, Peggy" ]
-    more_people: ""
+    people: [ "Glanville-Hicks, Peggy", "Cage, John" ]
+    more_people: [ "Schaeffer, Pierre", "Boulez, Pierre", "Henry, Pierre" ] 
     title: "“Tapesichord: The Music of Whistle and Bang,” *Vogue*, 78–81, 108"
     date: "July 1953"
     date_sort: "1953-07-01"
@@ -633,8 +633,8 @@ object_list:
     id: "037"
     old_id: "1.12h"
     maker: [ "L. T." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian" ]
     title: "“Concert and Recital: David Tudor, Pianist,” *New York Herald Tribune*"
     date: "15 April 1954"
     date_sort: "1954-04-15"
@@ -650,8 +650,8 @@ object_list:
     id: "038"
     old_id: "1.12i"
     maker: [ "T. M. S." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Brown, Earle", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Messiaen, Olivier", "Wolpe, Stefan" ]
     title: "“Concert and Recital: David Tudor, Pianist,” *New York Herald Tribune*, 22"
     date: "29 April 1954"
     date_sort: "1954-04-29"
@@ -667,8 +667,8 @@ object_list:
     id: "039"
     old_id: "1.12j"
     maker: 
-    people: ""
-    more_people: ""
+    people:  [ "Tudor, David", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Wolpe, Stefan" ]
     title: "“Musical Events: Old Horizons,” *New Yorker*, 125–33"
     date: "8 May 1954"
     date_sort: "1954-05-08"
@@ -684,8 +684,8 @@ object_list:
     id: "040"
     old_id: "1.12k"
     maker: [ "R. P." ]
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Feldman, Morton" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "“John Cage Offers Stereophonic Concert Including Eight Radios and Four Pianos,” *New York Times*"
     date: "31 May 1956"
     date_sort: "1956-05-31"
@@ -701,8 +701,8 @@ object_list:
     id: "041"
     old_id: "1.12m"
     maker: [ "Jay S. Harrison" ]
-    people: [ "Harrison, Jay S." ]
-    more_people: ""
+    people: [ "Harrison, Jay S.", "Feldman, Morton", "Cage, John", "Tudor, David", "Brown, Earle" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“New Music Concert Given at the Carl Fischer Hall,” *New York Herald Tribune*, 15"
     date: "31 May 1956"
     date_sort: "1956-05-31"
@@ -718,8 +718,8 @@ object_list:
     id: "042"
     old_id: "1.12n"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Brown, Earle", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Boulez, Pierre", "Pousseur, Henri", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“Music of the Future: Science Fiction for the Piano,” *The Times* (London)"
     date: "19 December 1956"
     date_sort: "1956-12-19"
@@ -735,8 +735,8 @@ object_list:
     id: "043"
     old_id: "1.12o"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Brown, Earle", "Feldman, Morton" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
     title: "“Mozart bevorzugte für das Spiel von Hausmusik. . . ,” *The Observer*"
     date: "15 December 1958"
     date_sort: "1958-12-15"
@@ -752,8 +752,8 @@ object_list:
     id: "044"
     old_id: "1.12p"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Brown, Earle", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“Der Kampf mit dem Drachen. In der Musikakademie wurde ein Klavier mit dem Stock geschlagen,” *The Observer*"
     date: "5 December 1958"
     date_sort: "1958-12-05"
@@ -820,7 +820,7 @@ object_list:
     id: "048"
     old_id: "1.15b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Sketches of Numbered Boxes)"
     date: "ca. 1953"
@@ -837,7 +837,7 @@ object_list:
     id: "049"
     old_id: "1.15c"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Sketches of Clusters)"
     date: "ca. 1953"
@@ -854,7 +854,7 @@ object_list:
     id: "050"
     old_id: "1.15d"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Quarter-note Realization)"
     date: "ca. 1953"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -2080,7 +2080,7 @@ object_list:
     id: "121"
     old_id: "2.15ac"
     maker: [ "Louis R. Guzzo" ]
-    people: [ "Guzzo, Louis R." ]
+    people: [ "Guzzo, Louis R.", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“Cage’s Electronic Music Amazes and Amuses,” *Seattle Times*"
     date: "27 September 1962"
@@ -2097,7 +2097,7 @@ object_list:
     id: "122"
     old_id: "2.15ad"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Bernstein, Leonard", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
     more_people: ""
     title: "“Far-Out at the Philharmonic,” *Time*, 79–80"
     date: "14 February 1964"
@@ -2114,7 +2114,7 @@ object_list:
     id: "123"
     old_id: "2.16a"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Letter from John Cage to David Tudor"
     date: "29 January 1958"
@@ -2131,7 +2131,7 @@ object_list:
     id: "124"
     old_id: "2.16b"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Letter from John Cage to David Tudor"
     date: "1951"
@@ -2148,8 +2148,8 @@ object_list:
     id: "125"
     old_id: "2.16c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolpe, Stefan", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "David Tudor’s press materials"
     date: "1959?"
     date_sort: "1959-01-01"
@@ -2165,7 +2165,7 @@ object_list:
     id: "126"
     old_id: "2.16d"
     maker: [ "James Klosty" ]
-    people: [ "Klosty, James" ]
+    people: [ "Klosty, James", "Tudor, David" ]
     more_people: ""
     title: "Letter from James Klosty to David Tudor"
     date: "1971"
@@ -2182,8 +2182,8 @@ object_list:
     id: "127"
     old_id: "2.17"
     maker: [ "Mary Caroline Richards (American, 1916–99)" ]
-    people: [ "Richards, Mary Caroline" ]
-    more_people: ""
+    people: [ "Richards, Mary Caroline", "Artaud, Antonin" ]
+    more_people: 
     title: "Antonin Artaud lecture for the Living Theatre"
     date: "1959"
     date_sort: "1959-01-01"
@@ -2199,7 +2199,7 @@ object_list:
     id: "128"
     old_id: "2.18"
     maker: [ "David Tudor (American, 1926–96)", "Antonin Artaud (French, 1896–1948)" ]
-    people: [ "Tudor, David", "Artaud, Antonin" ]
+    people: [ "Tudor, David", "Artaud, Antonin", "Richards, Mary Caroline" ]
     more_people: ""
     title: "David Tudor’s typescript of M. C. Richards’s English translation of Antonin Artaud’s “An Affective Athleticism”"
     date: ""
@@ -2216,7 +2216,7 @@ object_list:
     id: "129"
     old_id: "2.19a"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor performing John Cage’s *Water Music* at Darmstadt"
     date: "1958, or possibly 1956"
@@ -2233,7 +2233,7 @@ object_list:
     id: "130"
     old_id: "2.19b"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing John Cage’s *Concert for Piano and Orchestra*"
     date: "1958"
@@ -2250,7 +2250,7 @@ object_list:
     id: "131"
     old_id: "2.19c"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor preparing his second realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -2267,7 +2267,7 @@ object_list:
     id: "132"
     old_id: "2.19d"
     maker: [ "Manfred Leve (German, 1936–2012)" ]
-    people: [ "Leve, Manfred" ]
+    people: [ "Leve, Manfred", "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing at Galerie 22 in Düsseldorf, Germany"
     date: "14 October 1958"
@@ -2284,7 +2284,7 @@ object_list:
     id: "133"
     old_id: "2.19e"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "John Cage and David Tudor in the Tôkei-ji Temple Garden (Kanazawa, Japan)"
     date: "1962"
@@ -2301,7 +2301,7 @@ object_list:
     id: "134"
     old_id: "2.20"
     maker: 
-    people: ""
+    people: [ "Cunningham, Merce", "Cage, John" ]
     more_people: ""
     title: "Merce Cunningham conducting John Cage’s *Concert for Piano and Orchestra* at Town Hall"
     date: "15 May 1958"
@@ -2318,7 +2318,7 @@ object_list:
     id: "135"
     old_id: "2.21"
     maker: [ "Aram Avakian (American, 1926–87)" ]
-    people: [ "Avakian, Aram" ]
+    people: [ "Avakian, Aram", "Cunningham, Merce", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "John Cage, Merce Cunningham, and David Tudor at the Town Hall premiere of *Concert for Piano and Orchestra*"
     date: "May 1958"
@@ -2335,7 +2335,7 @@ object_list:
     id: "136"
     old_id: "2.22a"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Dynamics table for graph A for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2352,7 +2352,7 @@ object_list:
     id: "137"
     old_id: "2.22b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Auxiliary sound inventory for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2369,7 +2369,7 @@ object_list:
     id: "138"
     old_id: "2.22c"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the *Antic Meet* performance of John Cage’s *Solo for Piano* at the American Dance Festival"
     date: "August 1958"
@@ -2386,7 +2386,7 @@ object_list:
     id: "139"
     old_id: "2.22d"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the *Antic Meet* performance of John Cage’s *Concert for Piano and Orchestra* at the Phoenix Theatre, New York"
     date: "16 February 1960"
@@ -2403,7 +2403,7 @@ object_list:
     id: "140"
     old_id: "2.22e"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Cologne performance of John Cage’s *Solo for Piano*"
     date: "September 1958"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -2420,7 +2420,7 @@ object_list:
     id: "141"
     old_id: "2.22f"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Town Hall rehearsal and premiere of John Cage’s *Solo for Piano*"
     date: "15 May 1958"
@@ -2437,7 +2437,7 @@ object_list:
     id: "142"
     old_id: "2.22g"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Vienna performance of John Cage’s *Solo for Piano*"
     date: "19 November 1959"
@@ -2454,7 +2454,7 @@ object_list:
     id: "143"
     old_id: "2.22h"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Village Vanguard performance of John Cage’s *Solo for Piano*"
     date: "25 May 1958"
@@ -2471,7 +2471,7 @@ object_list:
     id: "144"
     old_id: "2.22i"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Grids and templates for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2488,7 +2488,7 @@ object_list:
     id: "145"
     old_id: "2.22j"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Index of graphs and pages from John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2505,7 +2505,7 @@ object_list:
     id: "146"
     old_id: "2.22k"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Map of graphs for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2522,7 +2522,7 @@ object_list:
     id: "147"
     old_id: "2.22l"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Notes for tape A for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2539,7 +2539,7 @@ object_list:
     id: "148"
     old_id: "2.22m"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Notes for tape B for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2556,7 +2556,7 @@ object_list:
     id: "149"
     old_id: "2.22n"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Realization fragment for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2573,7 +2573,7 @@ object_list:
     id: "150"
     old_id: "2.22o"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Reverse sequence of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2590,7 +2590,7 @@ object_list:
     id: "151"
     old_id: "2.22p"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Sketch of the graph sequence for the Cologne performance of John Cage’s *Solo for Piano*"
     date: "September 1958"
@@ -2607,7 +2607,7 @@ object_list:
     id: "152"
     old_id: "2.22q"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Unidentified sequence sketch for the first realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -2624,7 +2624,7 @@ object_list:
     id: "153"
     old_id: "2.22r"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Unidentified sketches for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2641,7 +2641,7 @@ object_list:
     id: "154"
     old_id: "3.01"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "David Tudor’s personal copy of Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2658,7 +2658,7 @@ object_list:
     id: "155"
     old_id: "3.02"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Typed instructions (in Italian and German) for Sylvano Bussotti’s *Five Pieces for David Tudor*"
     date: "1959"
@@ -2675,7 +2675,7 @@ object_list:
     id: "156"
     old_id: "3.03a"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s realization of *No. 1* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2692,7 +2692,7 @@ object_list:
     id: "157"
     old_id: "3.03b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s realization of *No. 4* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2709,7 +2709,7 @@ object_list:
     id: "158"
     old_id: "3.04"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s realization of *No. 3* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2726,7 +2726,7 @@ object_list:
     id: "159"
     old_id: "3.05"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Loose score sheets for Sylvano Bussotti’s *Pièces de chair II*"
     date: "1958–60"
@@ -2794,7 +2794,7 @@ object_list:
     id: "163"
     old_id: "3.08"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s tables and sketches for his realizations of *No. 4* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2811,7 +2811,7 @@ object_list:
     id: "164"
     old_id: "3.09"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Performance note for *No. 5* from *Piano Pieces for David Tudor*"
     date: "1959"
@@ -2862,7 +2862,7 @@ object_list:
     id: "167"
     old_id: "3.11b"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "25 August 1967"
@@ -2879,7 +2879,7 @@ object_list:
     id: "168"
     old_id: "3.11d"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Envelope from Sylvano Bussotti to David Tudor"
     date: "1959"
@@ -2896,7 +2896,7 @@ object_list:
     id: "169"
     old_id: "3.11e"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Ink drawing by Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -2930,7 +2930,7 @@ object_list:
     id: "171"
     old_id: "3.11g"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Envelope from Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -2947,7 +2947,7 @@ object_list:
     id: "172"
     old_id: "3.11h"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Signature on score fragment to David Tudor"
     date: "1959"
@@ -2964,7 +2964,7 @@ object_list:
     id: "173"
     old_id: "3.11i"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Ink drawing by Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -2998,7 +2998,7 @@ object_list:
     id: "175"
     old_id: "3.11k"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Miscellaneous scores by Sylvano Bussotti sent to David Tudor"
     date: "1959(?)"
@@ -3015,7 +3015,7 @@ object_list:
     id: "176"
     old_id: "3.11l"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Postcard from Sylvano Bussotti to David Tudor"
     date: "6 January 1965"
@@ -3032,7 +3032,7 @@ object_list:
     id: "177"
     old_id: "3.11m"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "25 April 1965"
@@ -3049,7 +3049,7 @@ object_list:
     id: "178"
     old_id: "3.11n"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "2 November 1959"
@@ -3066,7 +3066,7 @@ object_list:
     id: "179"
     old_id: "3.11o"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "24 May 1967"
@@ -3083,7 +3083,7 @@ object_list:
     id: "180"
     old_id: "3.11p"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -3100,7 +3100,7 @@ object_list:
     id: "181"
     old_id: "3.11q"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "22 May 1959"
@@ -3108,7 +3108,7 @@ object_list:
     year_filter: [ "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 51, folder 8"
-    extended_caption: "This is the letter Sylvano Bussotti included with his initial package of scores to DavidTudor. It makes explicit the high level of trust the composer has in the performer’s ability to realize his scores."
+    extended_caption: "This is the letter Sylvano Bussotti included with his initial package of scores to David Tudor. It makes explicit the high level of trust the composer has in the performer’s ability to realize his scores."
     credit: "Courtesy of the Sylvano Bussotti Estate."
     featured: 
     type: [ correspondence ]
@@ -3117,7 +3117,7 @@ object_list:
     id: "182"
     old_id: "3.12"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Postcard from Sylvano Bussotti and other avant-garde composers to David Tudor"
     date: "1959"
@@ -3134,8 +3134,8 @@ object_list:
     id: "183"
     old_id: "3.13a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Cage, John" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Musica d’Oggi, Conservatorio B. Marcello, Concerto del pianista David Tudor; *Nos. 5, 2*, and *3* from Sylvano Bussotti’s *Piano Pieces for David Tudor*"
     date: "12 November 1959"
     date_sort: "1959-11-12"
@@ -3151,8 +3151,8 @@ object_list:
     id: "184"
     old_id: "3.13b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Cardew, Cornelius", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Centro d’Arte degli Studenti dell’Università di Padova, 266 Concerto, David Tudor pianista, Sylvano Bussotti, *Piano Pieces for David Tudor*"
     date: "14 November 1959"
     date_sort: "1959-11-14"
@@ -3168,8 +3168,8 @@ object_list:
     id: "185"
     old_id: "3.13c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "Program from a Wesleyan University piano recital"
     date: "24 April 1961"
     date_sort: "1961-04-24"
@@ -3185,8 +3185,8 @@ object_list:
     id: "186"
     old_id: "3.14a"
     maker: [ "U. D." ]
-    people: ""
-    more_people: ""
+    people: [ "Bussotti, Sylvano", "Cage, John", "Tudor, David" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz" ]
     title: "“Concerto di Tudor a Venezia,” *L’Unità*, 4"
     date: "13 November 1959"
     date_sort: "1959-11-13"
@@ -3202,8 +3202,8 @@ object_list:
     id: "187"
     old_id: "3.14b"
     maker: [ "Lodovico Mamprin" ]
-    people: [ "Mamprin, Lodovico" ]
-    more_people: ""
+    people: [ "Mamprin, Lodovico", "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz" ]
     title: "“Tre concerti in Italia di musiche d’avanguardia,” *Giornale del Mattino*, 5"
     date: "15 November 1959"
     date_sort: "1959-11-15"
@@ -3219,8 +3219,8 @@ object_list:
     id: "188"
     old_id: "3.14c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Young, La Monte" ]
+    more_people: [ "Wolff, Christian" ]
     title: "“David Tudor Series Set,” *New York Times*"
     date: "8 March 1960"
     date_sort: "1960-03-08"
@@ -3236,7 +3236,7 @@ object_list:
     id: "189"
     old_id: "3.14d"
     maker: [ "Paul Henry Lang" ]
-    people: [ "Lang, Paul Henry" ]
+    people: [ "Lang, Paul Henry", "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "“Long-Hair Critic Reviews a Glove-Wearing Pianist,” *New York Herald Tribune*"
     date: "29 March 1960"
@@ -3253,8 +3253,8 @@ object_list:
     id: "190"
     old_id: "3.14e"
     maker: [ "Eric Salzman" ]
-    people: [ "Salzman, Eric" ]
-    more_people: ""
+    people: [ "Salzman, Eric", "Tudor, David", "Bussotti, Sylvano" ]
+    more_people: [ "Cardew, Cornelius", "Stockhausen, Karlheinz" ]
     title: "“Recital Is Given by David Tudor,” *New York Times*"
     date: "29 March 1960"
     date_sort: "1960-03-29"
@@ -3270,7 +3270,7 @@ object_list:
     id: "191"
     old_id: "3.14f"
     maker: [ "Ed Wallace" ]
-    people: [ "Wallace, Ed" ]
+    people: [ "Wallace, Ed", "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "“War on the Keys: Above Ground Test Deactivates Piano,” *New York World-Telegram and Sun*"
     date: "5 April 1960"
@@ -3287,8 +3287,8 @@ object_list:
     id: "192"
     old_id: "3.14g"
     maker: [ "Harold C. Schonberg" ]
-    people: [ "Schonberg, Harold C." ]
-    more_people: ""
+    people: [ "Schonberg, Harold C.", "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Feldman, Morton" ]
+    more_people: [ "Boulez, Pierre" ]
     title: "“The Far-Out Pianist,” *Harper’s Magazine*, 49–54"
     date: "June 1960"
     date_sort: "1960-06-01"
@@ -3304,7 +3304,7 @@ object_list:
     id: "193"
     old_id: "3.14h"
     maker: [ "Enrique Franco" ]
-    people: [ "Franco, Enrique" ]
+    people: [ "Franco, Enrique", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“David Tudor presenta un programa de musica experimental: Jean Martinon dirige La Nacional,” 21"
     date: "12 November 1960"
@@ -3321,8 +3321,8 @@ object_list:
     id: "194"
     old_id: "3.14i"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Cage, John" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "“Musikken der fik TV-Seerne til at Storme Radiohuset: Er den gale musik kun skruptosset?,” *Politiken*, 13"
     date: "30 July 1961"
     date_sort: "1961-07-30"
@@ -3338,7 +3338,7 @@ object_list:
     id: "195"
     old_id: "3.15"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Lecture notes on David Tudor’s performance practice as a pianist during the late 1950s and early ’60s"
     date: "early 1960s"
@@ -3355,7 +3355,7 @@ object_list:
     id: "196"
     old_id: "3.16"
     maker: [ "Manfred Leve (German, 1936–2012)" ]
-    people: [ "Leve, Manfred" ]
+    people: [ "Leve, Manfred", "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing with gloves"
     date: "ca. 1959"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1332,7 +1332,7 @@ object_list:
     id: "077"
     old_id: "2.09"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David", "Cage, John" ]
+    people: [ "Tudor, David", "Cage, John", "Oliveros, Pauline", "Subotnick, Morton" ]
     more_people: ""
     title: "Live performance of the first realization of John Cage’s *Concert for Piano and Orchestra* at Mills College"
     date: "1964"
@@ -1451,8 +1451,8 @@ object_list:
     id: "084"
     old_id: "2.14b"
     maker: 
-    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
-    more_people: [ "Ajemian, Maro", "Richards, Mary Caroline" ]
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David", "Richards, Mary Caroline" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "Press release for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1612,7 +1612,7 @@ object_list:
     year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 63, folder 5"
-    extended_caption: "The author of this mock review collages together a [*Harper’s Magazine* feature article on Davod Tudor](/image-index/192/), and includes a score reproduction, commentary on Tudor’s work, information about the performance, and a note about the virtues of Photostat-based typography. Though he seems not to have attended the concert, the writer’s observations about Tudor’s work (presumably based on the *Harper’s* article) exemplify the tendency of middlebrow critics to engage in their own armchair philosophizing about the upending of traditional ontologies of music. The author calls Tudor’s performance an indeterminate “thing,” and compares experimental notation to a tradition of formalized diagraming that is more familiar but equally complex—a football playbook."
+    extended_caption: "The author of this mock review collages together a [*Harper’s Magazine* feature article on David Tudor](/image-index/192/), and includes a score reproduction, commentary on Tudor’s work, information about the performance, and a note about the virtues of Photostat-based typography. Though he seems not to have attended the concert, the writer’s observations about Tudor’s work (presumably based on the *Harper’s* article) exemplify the tendency of middlebrow critics to engage in their own armchair philosophizing about the upending of traditional ontologies of music. The author calls Tudor’s performance an indeterminate “thing,” and compares experimental notation to a tradition of formalized diagraming that is more familiar but equally complex—a football playbook."
     credit: ""
     featured: 
     type: [ programs and flyers ]
@@ -1621,8 +1621,8 @@ object_list:
     id: "094"
     old_id: "2.15a"
     maker: [ "H. G." ]
-    people: [ "Tudor, David", "Cage, John" ]
-    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
+    people: [ "Tudor, David", "Cage, John", "Stockhausen, Karlheinz" ]
+    more_people: [ "Boulez, Pierre" ]
     title: "“Mäßiger Auftakt in Köln: Drei Premieren, darunter eine mit Wäscheklammern,” *Neue Rhein Zeitung*"
     date: "25 September 1958"
     date_sort: "1958-09-25"
@@ -1638,7 +1638,7 @@ object_list:
     id: "095"
     old_id: "2.15b"
     maker: [ "Dore Ashton" ]
-    people: [ "Ashton, Dore", "Cage, John" ]
+    people: [ "Ashton, Dore", "Cage, John", "Rauschenberg, Robert", "Johns, Jasper" ]
     more_people: ""
     title: "“Cage, Composer, Shows Calligraphy of Note,” review of the Stable Gallery show, *New York Times*"
     date: "6 May 1958"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1468,8 +1468,8 @@ object_list:
     id: "085"
     old_id: "2.14c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Cunningham, Merce" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "Program for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1485,7 +1485,7 @@ object_list:
     id: "086"
     old_id: "2.14d"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David", "Cunningham, Merce" ]
     more_people: ""
     title: "Program for Village Vanguard performance"
     date: "1958"
@@ -1502,8 +1502,8 @@ object_list:
     id: "087"
     old_id: "2.14e"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Bussotti, Sylvano" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Program for a concert by David Tudor and John Cage at Ann Arbor High School, Michigan, sponsored by the Dramatic Arts Center"
     date: "16 May 1960"
     date_sort: "1960-05-16"
@@ -1519,8 +1519,8 @@ object_list:
     id: "088"
     old_id: "2.14f"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David" ]
+    more_people: [ "Cardew, Cornelius", "Stockhausen, Karlheinz" ]
     title: "Program for Musik der Zeit, Westdeutscher Rundfunk Köln, Germany"
     date: "19 September 1958"
     date_sort: "1958-09-19"
@@ -1536,7 +1536,7 @@ object_list:
     id: "089"
     old_id: "2.14g"
     maker: 
-    people: ""
+    people: [ "Cunningham, Merce", "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Program for *Antic Meet* performance of John Cage’s *Solo for Piano*, Eleventh American Dance Festival, Connecticut College"
     date: "14 August 1958"
@@ -1553,7 +1553,7 @@ object_list:
     id: "090"
     old_id: "2.14h"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John", "Cunningham, Merce" ]
     more_people: ""
     title: "Program for *Antic Meet* performance of John Cage’s *Solo for Piano*, Twelfth American Dance Festival, Connecticut College"
     date: "13 August 1959"
@@ -1570,8 +1570,8 @@ object_list:
     id: "091"
     old_id: "2.14i"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Feldman, Morton", "Brown, Earle", "Bussotti, Sylvano", "Tudor, David" ]
+    more_people: [ "Wolff, Christian", "Cardew, Cornelius" ]
     title: "Program for Die Reihe III [Third series], Musikalische Jugend Österreichs, Internationale Gesellschaft für Neue Musik"
     date: "19 November 1959"
     date_sort: "1959-11-19"
@@ -1587,7 +1587,7 @@ object_list:
     id: "092"
     old_id: "2.14j"
     maker: [ "John Cage (American, 1912–92)", "Richard Kostelanetz (b. 1940)" ]
-    people: [ "Cage, John", "Kostelanetz, Richard" ]
+    people: [ "Cage, John", "Kostelanetz, Richard", "Tudor, David" ]
     more_people: ""
     title: "Liner notes for *Indeterminacy* recording"
     date: "1959; reissued 1992"
@@ -1604,8 +1604,8 @@ object_list:
     id: "093"
     old_id: "2.14k"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz", "Boulez, Pierre" ] 
     title: "Promotional collage of clippings and scores for a concert at the First Unitarian Society, Minneapolis, MN, printed in *The Potboiler* (January and February 1962)"
     date: "22 January 1961"
     date_sort: "1961-01-22"
@@ -1621,8 +1621,8 @@ object_list:
     id: "094"
     old_id: "2.15a"
     maker: [ "H. G." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John" ]
+    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
     title: "“Mäßiger Auftakt in Köln: Drei Premieren, darunter eine mit Wäscheklammern,” *Neue Rhein Zeitung*"
     date: "25 September 1958"
     date_sort: "1958-09-25"
@@ -1638,7 +1638,7 @@ object_list:
     id: "095"
     old_id: "2.15b"
     maker: [ "Dore Ashton" ]
-    people: [ "Ashton, Dore" ]
+    people: [ "Ashton, Dore", "Cage, John" ]
     more_people: ""
     title: "“Cage, Composer, Shows Calligraphy of Note,” review of the Stable Gallery show, *New York Times*"
     date: "6 May 1958"
@@ -1655,7 +1655,7 @@ object_list:
     id: "096"
     old_id: "2.15c"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“A Whistle, a ‘Slinky’ and a Bunch of Screws,” photograph by Sy Friedman, *New York Times*, X9"
     date: "11 May 1958"
@@ -1672,8 +1672,8 @@ object_list:
     id: "097"
     old_id: "2.15d"
     maker: [ "Jay S. Harrison" ]
-    people: [ "Harrison, Jay S." ]
-    more_people: ""
+    people: [ "Harrison, Jay S.", "Cage, John", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“John Cage Retrospective Is Presented at Town Hall,” *New York Herald Tribune*, 12"
     date: "16 May 1958"
     date_sort: "1958-05-16"
@@ -1689,8 +1689,8 @@ object_list:
     id: "098"
     old_id: "2.15e"
     maker: [ "Milew Kastendieck" ]
-    people: [ "Kastendieck, Milew" ]
-    more_people: ""
+    people: [ "Kastendieck, Milew", "Cage, John" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“Cage’s Music Still a Phenomenon,” *New York Journal-American*, 12"
     date: "16 May 1958"
     date_sort: "1958-05-16"
@@ -1706,8 +1706,8 @@ object_list:
     id: "099"
     old_id: "2.15f"
     maker: [ "Ross Parmenter" ]
-    people: [ "Parmenter, Ross" ]
-    more_people: ""
+    people: [ "Parmenter, Ross", "Cage, John", "Tudor, David", "Cuningham, Merce" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“Music: Experimenter: Zounds! Sound by John Cage at Town Hall,” *New York Times*, 20"
     date: "16 May 1958"
     date_sort: "1958-05-16"
@@ -1723,7 +1723,7 @@ object_list:
     id: "100"
     old_id: "2.15g"
     maker: [ "Louis Biancolli" ]
-    people: [ "Biancolli, Louis" ]
+    people: [ "Biancolli, Louis", "Cage, John" ]
     more_people: ""
     title: "“John Cage Gives Review of Work,” *New York World-Telegram and Sun*, 25"
     date: "16 May 1958"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -207,7 +207,7 @@ object_list:
     id: "012"
     old_id: "1.01"
     maker: [ "Morton Feldman (American, 1926–87)" ]
-    people: [ "Feldman, Morton" ]
+    people: [ "Feldman, Morton", "Tudor, David" ]
     more_people: ""
     title: "*Intersection 3* with a dedication to David Tudor"
     date: "1953"
@@ -241,7 +241,7 @@ object_list:
     id: "014"
     old_id: "1.03"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection 3*"
     date: "1953"
@@ -258,7 +258,7 @@ object_list:
     id: "015"
     old_id: "1.04"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Rereleased recording of David Tudor performing *Intersection 3*"
     date: "2007"
@@ -275,7 +275,7 @@ object_list:
     id: "016"
     old_id: "1.05"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Undated recording of David Tudor performing *Intersection 3*"
     date: ""
@@ -326,7 +326,7 @@ object_list:
     id: "019"
     old_id: "1.07a"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Animated score of David Tudor’s *Intersection 3* performance"
     date: "1953"
@@ -343,7 +343,7 @@ object_list:
     id: "020"
     old_id: "1.07b"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Audio sampler of Tudor’s sonorities for *Intersection 3*"
     date: "1953"
@@ -360,7 +360,7 @@ object_list:
     id: "021"
     old_id: "1.08"
     maker: [ "Morton Feldman (American, 1926–87)" ]
-    people: [ "Feldman, Morton" ]
+    people: [ "Feldman, Morton", "Tudor, David" ]
     more_people: ""
     title: "Letter from Morton Feldman to David Tudor"
     date: "15 June 1953"
@@ -411,8 +411,8 @@ object_list:
     id: "024"
     old_id: "1.11a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Boulez, Pierre", "Wolff, Christian" ]
     title: "Program for a concert featuring David Tudor at the Festival of Contemporary Arts, University of Illinois School of Music"
     date: "22 March 1953"
     date_sort: "1953-03-22"
@@ -428,8 +428,8 @@ object_list:
     id: "025"
     old_id: "1.11b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz", "Pousseur, Henri" ]
     title: "Program for Musik der Zeit, featuring David Tudor and John Cage at Nordwestdeutscher Rundfunk Köln"
     date: "26 November 1954"
     date_sort: "1954-11-26"
@@ -445,8 +445,8 @@ object_list:
     id: "026"
     old_id: "1.11c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Program for a concert featuring David Tudor and John Cage at the University of British Columbia"
     date: "2 December 1955"
     date_sort: "1955-12-02"
@@ -462,8 +462,8 @@ object_list:
     id: "027"
     old_id: "1.11d"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Webern, Anton", "Boulez, Pierre", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“WHRB Presents David Tudor, Pianist, & John Cage in a Program for ‘New’ Music for Piano at Harvard University”"
     date: "20 April 1956"
     date_sort: "1956-04-20"
@@ -479,8 +479,8 @@ object_list:
     id: "028"
     old_id: "1.11e"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Brown, Earle", "Feldman, Morton" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
     title: "Program for a concert featuring David Tudor at the Vortragssaal at the Akademie für Musik und darstellende Kunst"
     date: "30 November 1956"
     date_sort: "1956-11-30"
@@ -496,8 +496,8 @@ object_list:
     id: "029"
     old_id: "1.11f"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Program for a performance featuring David Tudor and John Cage"
     date: "n.d."
     date_sort: ""
@@ -513,8 +513,8 @@ object_list:
     id: "030"
     old_id: "1.12a"
     maker: [ "George W. Stowe" ]
-    people: [ "Stowe, George W." ]
-    more_people: ""
+    people: [ "Stowe, George W.", "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Varese, Edgar" ]
     title: "“David Tudor Program Opens Sunday Afternoon Series,” *Hartford Times*"
     date: "November 1953"
     date_sort: "1953-11-01"
@@ -530,7 +530,7 @@ object_list:
     id: "031"
     old_id: "1.12b"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cunningham, Merce" ]
     more_people: ""
     title: "“Merce Cunningham of New York”"
     date: "August 1953?"
@@ -548,8 +548,8 @@ object_list:
     id: "032"
     old_id: "1.12c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cunningham, Merce" ]
+    more_people: [ "Wolpe, Stefan" ]
     title: "“Concerts Are Arranged at College,” *Asheville Citizen-Times*"
     date: "21 June 1953"
     date_sort: "1953-06-21"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1451,8 +1451,8 @@ object_list:
     id: "084"
     old_id: "2.14b"
     maker: 
-    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David", "Richards, Mary Caroline" ]
-    more_people: [ "Ajemian, Maro" ]
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro", "Richards, Mary Caroline" ]
     title: "Press release for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1740,8 +1740,8 @@ object_list:
     id: "101"
     old_id: "2.15h"
     maker: [ "Margaret Lloyd" ]
-    people: [ "Lloyd, Margaret" ]
-    more_people: ""
+    people: [ "Lloyd, Margaret", "Cage, John", "Cunningham, Merce", "Feldman, Morton", "Tudor, David" ]
+    more_people: [ "Rauschenberg, Robert" ]
     title: "“Modern American Dance in Connecticut: Contrasting Styles Seen in Eleventh Annual,” *Christian Science Monitor*"
     date: "23 August 1958"
     date_sort: "1958-08-23"
@@ -1757,7 +1757,7 @@ object_list:
     id: "102"
     old_id: "2.15i"
     maker: [ "H. R." ]
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“In der Werkstatt der direktiven Freiheit,” *Kölnische Rundschau*"
     date: "21 September 1958"
@@ -1774,8 +1774,8 @@ object_list:
     id: "103"
     old_id: "2.15j"
     maker: [ "M. F." ]
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David" ]
+    more_people: [ "Boulez, Pierre", "Stockhausen, Karlheinz" ]
     title: "“Ein Ding mit Pfiff: Avantgardisten im ersten Abend ‘Musik der Zeit,’” *Neue Rhein Zeitung*"
     date: "22 September 1958"
     date_sort: "1958-09-22"
@@ -1791,8 +1791,8 @@ object_list:
     id: "104"
     old_id: "2.15k"
     maker: [ "Herbert Schultz" ]
-    people: [ "Schultz, Herbert" ]
-    more_people: ""
+    people: [ "Schultz, Herbert", "Cage, John", "Tudor, David" ]
+    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
     title: "“Nicht mehr der Ton macht die Musik,” *Der Mittag*"
     date: "23 September 1958"
     date_sort: "1958-09-23"
@@ -1808,8 +1808,8 @@ object_list:
     id: "105"
     old_id: "2.15l"
     maker: [ "Diether de la Motte" ]
-    people: [ "de la Motte, Diether" ]
-    more_people: ""
+    people: [ "de la Motte, Diether", "Cage, John", "Tudor, David" ]
+    more_people: [ "Boulez, Pierre", "Stockhausen, Karlheinz" ]
     title: "“Musik der Zeit: Demonstration neuer Kompositionstechniken,” *Rheinische Post*"
     date: "23 September 1958"
     date_sort: "1958-09-23"
@@ -1825,7 +1825,7 @@ object_list:
     id: "106"
     old_id: "2.15m"
     maker: [ "HvL" ]
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“Im Klavierkonzert ging es absunderlich her,” *Westdeutsche Rundschau Wuppertal*"
     date: "23 September 1958"
@@ -1842,8 +1842,8 @@ object_list:
     id: "107"
     old_id: "2.15n"
     maker: [ "Friedrich Berger" ]
-    people: [ "Berger, Friedrich" ]
-    more_people: ""
+    people: [ "Berger, Friedrich", "Cage, John", "Tudor, David"  ]
+    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
     title: "“Alibi für die Gestrigen,” *Kölner Stadt-Anzeiger*"
     date: "24 September 1958"
     date_sort: "1958-09-24"
@@ -1859,7 +1859,7 @@ object_list:
     id: "108"
     old_id: "2.15o"
     maker: [ "Heinrich Lindlar" ]
-    people: [ "Lindlar, Heinrich" ]
+    people: [ "Lindlar, Heinrich", "Cage, John" ]
     more_people: ""
     title: "“Was man hörte, war verwirrend: Fragwürdiges Funk-Konzert aus Köln mit ‘Musik der Zeit,’” *Die Welt*"
     date: "25 September 1958"
@@ -1876,7 +1876,7 @@ object_list:
     id: "109"
     old_id: "2.15p"
     maker: [ "Kurt Driesch" ]
-    people: [ "Driesch, Kurt" ]
+    people: [ "Driesch, Kurt", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“‘Avantgardistische Musik’ am Abgrund: Europäische Erstauffühurng von John Cage’s ‘Klavierkonzert’ in Köln,” *Rhein Neckar-Azeitung*"
     date: "30 September 1958"
@@ -1893,7 +1893,7 @@ object_list:
     id: "110"
     old_id: "2.15q"
     maker: [ "H. H. Stuckenschmidt" ]
-    people: [ "Stuckenschmidt, H. H." ]
+    people: [ "Stuckenschmidt, H. H.", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“Sessions on Modern Music Held Near Darmstadt,” *Musical America*, 18–19, 34"
     date: "October 1958"
@@ -1910,8 +1910,8 @@ object_list:
     id: "111"
     old_id: "2.15r"
     maker: [ "A. H." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Pousseur, Henri", "Messaien, Olivier" ]
     title: "“David Tudor in Piano Recital,” *New York Herald Tribune*, 11"
     date: "20 March 1959"
     date_sort: "1959-03-20"
@@ -1927,7 +1927,7 @@ object_list:
     id: "112"
     old_id: "2.15s"
     maker: [ "Edward Cannel" ]
-    people: [ "Cannel, Edward" ]
+    people: [ "Cannel, Edward", "Cage, John" ]
     more_people: ""
     title: "“Little Thing Like Mushroom Can Change Destiny,” *Oregon Journal*"
     date: "5 July 1959"
@@ -1944,8 +1944,8 @@ object_list:
     id: "113"
     old_id: "2.15t"
     maker: [ "Doris Hering" ]
-    people: [ "Hering, Doris" ]
-    more_people: ""
+    people: [ "Hering, Doris", "Tudor, David", "Cunningham, Merce" ]
+    more_people: [ "Shearer, Sybil" ]
     title: "“The ‘Good Guys’ Versus the ‘Bad Guys’: Twelfth American Dance Festival,” *Dance Magazine*, 31–35, 82"
     date: "October 1959"
     date_sort: "1959-10-01"
@@ -1961,7 +1961,7 @@ object_list:
     id: "114"
     old_id: "2.15u"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“John Cage: Indeterminacy,” *Time*, 65"
     date: "2 November 1959"
@@ -1978,7 +1978,7 @@ object_list:
     id: "115"
     old_id: "2.15v"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“Tumulte im Mozart-Saal des Konzerthauses,” *Neues Österreich*"
     date: "21 November 1959"
@@ -1995,7 +1995,7 @@ object_list:
     id: "116"
     old_id: "2.15w"
     maker: [ "Eric Salzman" ]
-    people: [ "Salzman, Eric" ]
+    people: [ "Salzman, Eric", "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“John Cage in Story Hour for Some Friends,” *New York Times*"
     date: "26 January 1960"
@@ -2012,8 +2012,8 @@ object_list:
     id: "117"
     old_id: "2.15x"
     maker: [ "Fred Grunfeld" ]
-    people: [ "Grunfeld, Fred" ]
-    more_people: ""
+    people: [ "Grunfeld, Fred", "Cage, John", "Feldman, Morton" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“Cage Without Bars,” *The Reporter*, 35, 37"
     date: "4 February 1960"
     date_sort: "1960-02-04"
@@ -2029,8 +2029,8 @@ object_list:
     id: "118"
     old_id: "2.15y"
     maker: [ "Walter Terry" ]
-    people: [ "Terry, Walter" ]
-    more_people: ""
+    people: [ "Terry, Walter", "Cunningham, Merce", "Cage, John", "Feldman, Morton", "Tudor, David" ]
+    more_people: [ "Wolff, Christian" ]
     title: "“Cunningham Dance Group Gives Avant Garde Works,” *New York Herald Tribune*, 19"
     date: "17 February 1960"
     date_sort: "1960-02-17"
@@ -2046,8 +2046,8 @@ object_list:
     id: "119"
     old_id: "2.15z"
     maker: [ "Paul Henry Lang" ]
-    people: [ "Lang, Paul Henry" ]
-    more_people: ""
+    people: [ "Lang, Paul Henry", "Tudor, David" ]
+    more_people: [ "Carter, Elliott" ]
     title: "“What Is Offered by Electronic Age?,” *New York Herald Tribune*, 6"
     date: "10 April 1960"
     date_sort: "1960-04-10"
@@ -2063,7 +2063,7 @@ object_list:
     id: "120"
     old_id: "2.15ab"
     maker: [ "John K. Sherman" ]
-    people: [ "Sherman, John K." ]
+    people: [ "Sherman, John K.", "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
     more_people: ""
     title: "“Music to Hear—and Unhear,” *Minneapolis Star*"
     date: "1961"


### PR DESCRIPTION
Added "people" and "more people" to the first 100 objects (and corrected one typo I found in an extended caption). 

There are a couple representative objects you might take a look at to make sure you agree with how I treated them: 
id: 012, id: 084, and id: 095. 