### PR TITLE
Scores adding "people" (objects thru 200)

### DIFF
--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -463,7 +463,7 @@ object_list:
     old_id: "1.11d"
     maker: 
     people: [ "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
-    more_people: [ "Webern, Anton", "Boulez, Pierre", "Stockhausen, Karlheinz", "Wolff, Christian" ]
+    more_people: [ "Boulez, Pierre", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“WHRB Presents David Tudor, Pianist, & John Cage in a Program for ‘New’ Music for Piano at Harvard University”"
     date: "20 April 1956"
     date_sort: "1956-04-20"
@@ -667,8 +667,8 @@ object_list:
     id: "039"
     old_id: "1.12j"
     maker: 
-    people:  [ "Tudor, David", "Feldman, Morton", "Cage, John" ]
-    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Wolpe, Stefan" ]
+    people:  [ "Tudor, David", "Feldman, Morton", "Cage, John", "Wolff, Christian", "Boulez, Pierre", "Wolpe, Stefan" ]
+    more_people:
     title: "“Musical Events: Old Horizons,” *New Yorker*, 125–33"
     date: "8 May 1954"
     date_sort: "1954-05-08"
@@ -735,8 +735,8 @@ object_list:
     id: "043"
     old_id: "1.12o"
     maker: 
-    people: [ "Cage, John", "Tudor, David", "Brown, Earle", "Feldman, Morton" ]
-    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
+    people: [ "Cage, John", "Tudor, David", "Brown, Earle", "Feldman, Morton", "Wolff, Christian", "Stockhausen, Karlheinz", "Nilsson, Bo" ]
+    more_people:
     title: "“Mozart bevorzugte für das Spiel von Hausmusik. . . ,” *The Observer*"
     date: "15 December 1958"
     date_sort: "1958-12-15"
@@ -803,7 +803,7 @@ object_list:
     id: "047"
     old_id: "1.15a"
     maker: [ "Morton Feldman (American, 1926–87)" ]
-    people: [ "Feldman, Morton" ]
+    people: [ "Feldman, Morton", "Tudor, David" ]
     more_people: ""
     title: "*Intersection +*"
     date: "1953"
@@ -1007,8 +1007,8 @@ object_list:
     id: "059"
     old_id: "1.18"
     maker: 
-    people: [ "Brown, Earle", "Cage, John", "Feldman, Morton", "Tudor, David" ]
-    more_people: [ "Wolff, Christian" ]
+    people: [ "Brown, Earle", "Cage, John", "Feldman, Morton", "Tudor, David", "Wolff, Christian" ]
+    more_people: 
     title: "Christian Wolff, Earle Brown, John Cage, David Tudor, and Morton Feldman at the Capitol Records building in New York"
     date: "ca. 1953"
     date_sort: "1953-01-01"
@@ -1024,7 +1024,7 @@ object_list:
     id: "060"
     old_id: "2.01a"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "David Tudor’s copy of John Cage’s *Solo for Piano*, from *Concert for Piano and Orchestra*"
     date: "1957–58"
@@ -1041,7 +1041,7 @@ object_list:
     id: "061"
     old_id: "2.01b"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "David Tudor’s copy of the conductor’s part for *Concert for Piano and Orchestra*"
     date: "1957–58"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -871,7 +871,7 @@ object_list:
     id: "051"
     old_id: "1.15e"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (32nd-note Realization)"
     date: "n.d."
@@ -888,7 +888,7 @@ object_list:
     id: "052"
     old_id: "1.15f"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Alternative 32nd-note Realization)"
     date: "n.d."
@@ -922,7 +922,7 @@ object_list:
     id: "054"
     old_id: "1.16b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection 2*"
     date: "early 1950s"
@@ -939,7 +939,7 @@ object_list:
     id: "055"
     old_id: "1.17a"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor performing a work by John Cage in London"
     date: "1954"
@@ -956,7 +956,7 @@ object_list:
     id: "056"
     old_id: "1.17b"
     maker: 
-    people: ""
+    people: [ "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing in Spain"
     date: "1950s"
@@ -973,7 +973,7 @@ object_list:
     id: "057"
     old_id: "1.17c"
     maker: 
-    people: ""
+    people: [ "Tudor, David" ]
     more_people: ""
     title: "David Tudor as a young man at the piano"
     date: "1950s"
@@ -990,7 +990,7 @@ object_list:
     id: "058"
     old_id: "1.17d"
     maker: 
-    people: ""
+    people: [ "Tudor, David" ]
     more_people: ""
     title: "David Tudor as young man at the piano"
     date: "1950s"
@@ -1007,8 +1007,8 @@ object_list:
     id: "059"
     old_id: "1.18"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Brown, Earle", "Cage, John", "Feldman, Morton", "Tudor, David" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Christian Wolff, Earle Brown, John Cage, David Tudor, and Morton Feldman at the Capitol Records building in New York"
     date: "ca. 1953"
     date_sort: "1953-01-01"
@@ -1092,7 +1092,7 @@ object_list:
     id: "064"
     old_id: "2.02"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "First realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -1109,7 +1109,7 @@ object_list:
     id: "065"
     old_id: "2.03"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Supplementary score pages for the first realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -1126,7 +1126,7 @@ object_list:
     id: "066"
     old_id: "2.05"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Pencil draft of the second realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -1143,7 +1143,7 @@ object_list:
     id: "067"
     old_id: "2.06"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Final version of the second realization of John Cage’s *Solo for Piano* for the *Indeterminacy* recording (1959)"
     date: "1958"
@@ -1298,7 +1298,7 @@ object_list:
     id: "075"
     old_id: "2.07"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the first realization of John Cage’s *Concert for Piano and Orchestra* at Town Hall"
     date: "1958"
@@ -1315,7 +1315,7 @@ object_list:
     id: "076"
     old_id: "2.08"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Studio recording of the second realization of John Cage’s *Solo for Piano* for with Cage’s *Indeterminacy* stories"
     date: "1959"
@@ -1332,7 +1332,7 @@ object_list:
     id: "077"
     old_id: "2.09"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the first realization of John Cage’s *Concert for Piano and Orchestra* at Mills College"
     date: "1964"
@@ -1349,7 +1349,7 @@ object_list:
     id: "078"
     old_id: "2.10"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Studio recording of David Tudor performing *Concert for Piano and Orchestra*"
     date: "1993"
@@ -1366,7 +1366,7 @@ object_list:
     id: "079"
     old_id: "2.11"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Performance of the second realization of John Cage’s *Solo for Piano*"
     date: ""
@@ -1383,7 +1383,7 @@ object_list:
     id: "080"
     old_id: "2.12"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the *Solo for Piano* at the Philadelphia Museum of Art"
     date: "11 September 1982"
@@ -1400,7 +1400,7 @@ object_list:
     id: "081"
     old_id: "2.13a"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Live performance of the *Solo for Piano* at the Almeida Theatre in London"
     date: "13 June 1986"
@@ -1417,7 +1417,7 @@ object_list:
     id: "082"
     old_id: "2.13b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor’s Sonorities for John Cage’s *Solo for Piano*"
     date: ""
@@ -1434,8 +1434,8 @@ object_list:
     id: "083"
     old_id: "2.14a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "Flyer for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1451,8 +1451,8 @@ object_list:
     id: "084"
     old_id: "2.14b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro", "Richards, Mary Caroline" ]
     title: "Press release for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -4277,7 +4277,7 @@ object_list:
     id: "251"
     old_id: "5.02m"
     maker: [ "Phoebe Berglund" ]
-    people: [ "Berglund, Phoebe" ]
+    people: [ "Berglund, Phoebe", "De Maria, Walter" ]
     more_people: ""
     title: "*SKY, STONE, SEA* (2021), after Walter De Maria’s *Beach Crawl* (1960), at Marsha P. Johnson State Park Beach, Brooklyn, NY, performed by Phoebe Berglund Dance Troupe"
     date: "2021"
@@ -4294,7 +4294,7 @@ object_list:
     id: "252"
     old_id: "5.02o"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Lee, Jeanne" ]
     more_people: ""
     title: "*The text on the opposite page may be used in any way as a score for solo or group readings, musical or dramatic performances, looking, smelling, anything else &/or nothing at all* (July 1961), performed by Jackson Mac Low and Jeanne Lee at Town Hall, New York, NY"
     date: "13 September 1966"
@@ -4311,7 +4311,7 @@ object_list:
     id: "253"
     old_id: "5.02p"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Lee, Jeanne", "Neuhaus, Max", "Tenney, James" ]
     more_people: ""
     title: "*The text on the opposite page may be used in any way as a score for solo or group readings, musical or dramatic performances, looking, smelling, anything else &/or nothing at all* (July 1961), performed by Jackson Mac Low and Jeanne Lee (voices) with Max Neuhaus and James Tenney (electronics) at Town Hall, New York, NY"
     date: "13 September 1966"
@@ -4329,7 +4329,7 @@ object_list:
     old_id: "5.02q"
     maker: [ "Simone Forti (American, b. 1935)" ]
     people: [ "Forti, Simone" ]
-    more_people: ""
+    more_people: [ "Martin, Julie", "Kaye, Pooh" ]
     title: "Performances of Simone Forti’s *Huddle* and *Slant Board*, from the event *An Evening of Dance Constructions,* Museum of Contemporary Art, Los Angeles, CA"
     date: "1961; performed 2004; film released 2009"
     date_sort: "2004-01-01"
@@ -4345,8 +4345,8 @@ object_list:
     id: "255"
     old_id: "5.03"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Brecht, George", "Brown, Earle", "Cage, John", "Young, La Monte", "De Maria, Walter", "Ono, Yoko" ]
+    more_people: [ "Higgins, Dick", "Flynt, Henry", "Ichiyanagi, Toshi" ]
     title: "Program from a fundraising concert for *An Anthology of Chance Operations* at the Living Theatre, New York, NY"
     date: "8 January 1962"
     date_sort: "1962-01-08"
@@ -4362,8 +4362,8 @@ object_list:
     id: "256"
     old_id: "5.04"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Young, La Monte", "Mac Low, Jackson" ]
+    more_people: [ "Paik, Nam June", "Riley, Terry", "Wolff, Christian" ]
     title: "Program from a fundraising concert for *An Anthology of Chance Operations* at the Living Theatre, New York, NY"
     date: "5 February 1962"
     date_sort: "1962-02-05"
@@ -4379,8 +4379,8 @@ object_list:
     id: "257"
     old_id: "5.05a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Young, La Monte", "Ono, Yoko" ]
+    more_people: 
     title: "Flyer for “Three Evenings of Picnic and Electronic Music by Richard Maxfield,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "28–30 April 1961"
     date_sort: "1961-04-28"
@@ -4396,7 +4396,7 @@ object_list:
     id: "258"
     old_id: "5.05b"
     maker: 
-    people: ""
+    people: [ "Young, La Monte", "Ono, Yoko" ]
     more_people: ""
     title: "Flyer for “Compositions by La Monte Young,” part of the concert series organized by Yoko Ono and Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "19–20 May 1961"
@@ -4414,7 +4414,7 @@ object_list:
     id: "259"
     old_id: "5.05c"
     maker: 
-    people: ""
+    people: [ "Young, La Monte", "Ono, Yoko" ]
     more_people: ""
     title: "Program for “Compositions by La Monte Young,” part of the concert series organized by Yoko Ono and Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "19–20 May 1961"
@@ -4432,7 +4432,7 @@ object_list:
     id: "260"
     old_id: "5.06"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte" ]
     more_people: ""
     title: "Flyer advertising *An Anthology of Chance Operations*"
     date: "1962"
@@ -4449,8 +4449,8 @@ object_list:
     id: "261"
     old_id: "5.07"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Young, La Monte", "Rainer, Yvonne", "Brecht, George" ]
+    more_people: [ "Schneemann, Carolee", "Rauschenberg, Robert", "Monk, Meredith", "Neuhaus, Max", "Corner, Philip", "Tenney, James" ]
     title: "List of the Judson Dance Theater’s dance concerts, 1961–66"
     date: "ca. 1966"
     date_sort: "1966-01-01"
@@ -4466,7 +4466,7 @@ object_list:
     id: "262"
     old_id: "5.08"
     maker: 
-    people: ""
+    people: [ "Brecht, George" ]
     more_people: ""
     title: "Announcement for the George Brecht solo exhibition *toward EVENTS: an arrangement*, at the Reuben Gallery, New York, NY"
     date: "1959"
@@ -4483,7 +4483,7 @@ object_list:
     id: "263"
     old_id: "5.09"
     maker: 
-    people: ""
+    people: [ "Young, La Monte", "Cale, John", "Zazeela, Marian", "Conrad, Tony" ]
     more_people: ""
     title: "Program for a performance by the group Theatre of Eternal Music, with La Monte Young, John Cale, Marian Zazeela, and Tony Conrad"
     date: "ca. 1965"
@@ -4500,7 +4500,7 @@ object_list:
     id: "264"
     old_id: "5.10"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Cage, John" ]
     more_people: ""
     title: "Postcard from George Brecht to John Cage"
     date: "n.d."
@@ -4517,7 +4517,7 @@ object_list:
     id: "265"
     old_id: "5.11a"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Maciunas, George" ]
     more_people: ""
     title: "Letter from John Cage to George Maciunas"
     date: "3 February 1966"
@@ -4534,7 +4534,7 @@ object_list:
     id: "266"
     old_id: "5.11b"
     maker: [ "Nam June Paik (Korean, 1932–2006)" ]
-    people: [ "Paik, Nam June" ]
+    people: [ "Paik, Nam June", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Nam June Paik to George Maciunas"
     date: "14 November 1967"
@@ -4568,7 +4568,7 @@ object_list:
     id: "268"
     old_id: "5.11da"
     maker: [ "Dick Higgins (American, 1938–98)" ]
-    people: [ "Higgins, Dick" ]
+    people: [ "Higgins, Dick", "Maciunas, George", "Knowles, Alison", "Mac Low, Jackson" ]
     more_people: ""
     title: "Letter from Dick Higgins to George Maciunas"
     date: "17 August 1966"
@@ -4585,7 +4585,7 @@ object_list:
     id: "269"
     old_id: "5.11db"
     maker: [ "Dick Higgins (American, 1938–98)" ]
-    people: [ "Higgins, Dick" ]
+    people: [ "Higgins, Dick", "Maciunas, George", "Knowles, Alison" ]
     more_people: ""
     title: "Letter from Dick Higgins to George Maciunas"
     date: "22 August 1966"
@@ -4602,7 +4602,7 @@ object_list:
     id: "270"
     old_id: "5.11dc"
     maker: [ "Dick Higgins (American, 1938–98)" ]
-    people: [ "Higgins, Dick" ]
+    people: [ "Higgins, Dick", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Dick Higgins to George Maciunas"
     date: "23 August 1966"
@@ -4619,7 +4619,7 @@ object_list:
     id: "271"
     old_id: "5.11e"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Higgins, Dick" ]
     more_people: ""
     title: "Letters from George Maciunas to Dick Higgins"
     date: "18 January 1962 and February 1963"
@@ -4670,8 +4670,8 @@ object_list:
     id: "274"
     old_id: "5.12a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Mac Low, Jackson" ]
+    more_people: [ "Higgins, Dick" ]
     title: "Draft program titled “The Living Theatre presents NEW MUSIC performed by the Audio Visual Group”"
     date: "1 August 1960"
     date_sort: "1960-08-01"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -565,7 +565,7 @@ object_list:
     id: "033"
     old_id: "1.12d"
     maker: 
-    people: ""
+    people: [ "Cage, John" ]
     more_people: ""
     title: "“Cage to Perform ‘Abstract’ Music,” *Daily Illini*"
     date: "24 March 1953"
@@ -582,8 +582,8 @@ object_list:
     id: "034"
     old_id: "1.12e"
     maker: [ "Duffy Defibaugh" ]
-    people: [ "Defibaugh, Duffy" ]
-    more_people: ""
+    people: [ "Defibaugh, Duffy", "Cage, John", "Brown, Earle" ]
+    more_people: [ "Barron, Bebe and Louis", "Henry, Pierre" ]
     title: "“‘Magnetic Music’ Not Ready,” *Daily Illini*"
     date: "March 1953"
     date_sort: "1953-03-01"
@@ -599,8 +599,8 @@ object_list:
     id: "035"
     old_id: "1.12f"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Defibaugh, Duffy", "Cage, John", "Brown, Earle" ]
+    more_people: [ "Barron, Bebe and Louis", "Henry, Pierre" ]
     title: "Front page of the *Daily Illini*"
     date: "March 1953"
     date_sort: "1953-03-01"
@@ -616,8 +616,8 @@ object_list:
     id: "036"
     old_id: "1.12g"
     maker: [ "Peggy Glanville-Hicks" ]
-    people: [ "Glanville-Hicks, Peggy" ]
-    more_people: ""
+    people: [ "Glanville-Hicks, Peggy", "Cage, John" ]
+    more_people: [ "Schaeffer, Pierre", "Boulez, Pierre", "Henry, Pierre" ] 
     title: "“Tapesichord: The Music of Whistle and Bang,” *Vogue*, 78–81, 108"
     date: "July 1953"
     date_sort: "1953-07-01"
@@ -633,8 +633,8 @@ object_list:
     id: "037"
     old_id: "1.12h"
     maker: [ "L. T." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian" ]
     title: "“Concert and Recital: David Tudor, Pianist,” *New York Herald Tribune*"
     date: "15 April 1954"
     date_sort: "1954-04-15"
@@ -650,8 +650,8 @@ object_list:
     id: "038"
     old_id: "1.12i"
     maker: [ "T. M. S." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Brown, Earle", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Messiaen, Olivier", "Wolpe, Stefan" ]
     title: "“Concert and Recital: David Tudor, Pianist,” *New York Herald Tribune*, 22"
     date: "29 April 1954"
     date_sort: "1954-04-29"
@@ -667,8 +667,8 @@ object_list:
     id: "039"
     old_id: "1.12j"
     maker: 
-    people: ""
-    more_people: ""
+    people:  [ "Tudor, David", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Wolpe, Stefan" ]
     title: "“Musical Events: Old Horizons,” *New Yorker*, 125–33"
     date: "8 May 1954"
     date_sort: "1954-05-08"
@@ -684,8 +684,8 @@ object_list:
     id: "040"
     old_id: "1.12k"
     maker: [ "R. P." ]
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Feldman, Morton" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "“John Cage Offers Stereophonic Concert Including Eight Radios and Four Pianos,” *New York Times*"
     date: "31 May 1956"
     date_sort: "1956-05-31"
@@ -701,8 +701,8 @@ object_list:
     id: "041"
     old_id: "1.12m"
     maker: [ "Jay S. Harrison" ]
-    people: [ "Harrison, Jay S." ]
-    more_people: ""
+    people: [ "Harrison, Jay S.", "Feldman, Morton", "Cage, John", "Tudor, David", "Brown, Earle" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“New Music Concert Given at the Carl Fischer Hall,” *New York Herald Tribune*, 15"
     date: "31 May 1956"
     date_sort: "1956-05-31"
@@ -718,8 +718,8 @@ object_list:
     id: "042"
     old_id: "1.12n"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Brown, Earle", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Boulez, Pierre", "Pousseur, Henri", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“Music of the Future: Science Fiction for the Piano,” *The Times* (London)"
     date: "19 December 1956"
     date_sort: "1956-12-19"
@@ -735,8 +735,8 @@ object_list:
     id: "043"
     old_id: "1.12o"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Brown, Earle", "Feldman, Morton" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
     title: "“Mozart bevorzugte für das Spiel von Hausmusik. . . ,” *The Observer*"
     date: "15 December 1958"
     date_sort: "1958-12-15"
@@ -752,8 +752,8 @@ object_list:
     id: "044"
     old_id: "1.12p"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Brown, Earle", "Feldman, Morton", "Cage, John" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“Der Kampf mit dem Drachen. In der Musikakademie wurde ein Klavier mit dem Stock geschlagen,” *The Observer*"
     date: "5 December 1958"
     date_sort: "1958-12-05"
@@ -820,7 +820,7 @@ object_list:
     id: "048"
     old_id: "1.15b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Sketches of Numbered Boxes)"
     date: "ca. 1953"
@@ -837,7 +837,7 @@ object_list:
     id: "049"
     old_id: "1.15c"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Sketches of Clusters)"
     date: "ca. 1953"
@@ -854,7 +854,7 @@ object_list:
     id: "050"
     old_id: "1.15d"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection +* (Quarter-note Realization)"
     date: "ca. 1953"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -4278,7 +4278,7 @@ object_list:
     old_id: "5.02m"
     maker: [ "Phoebe Berglund" ]
     people: [ "Berglund, Phoebe", "De Maria, Walter" ]
-    more_people: ""
+    more_people: [ "Johnson, Joseph Allan", "Antinozzi, Julia", "Brandano, Juli", "Gray, Wendell, II", "Grennan, Leanna", "Heintzelman, Amelia", "Lloyd, Jordan Demetrius", "Manns, Jade", "Samuels, Leah", "Wasserman-Smith, Ella" ]
     title: "*SKY, STONE, SEA* (2021), after Walter De Maria’s *Beach Crawl* (1960), at Marsha P. Johnson State Park Beach, Brooklyn, NY, performed by Phoebe Berglund Dance Troupe"
     date: "2021"
     date_sort: "2021-01-01"
@@ -4432,8 +4432,8 @@ object_list:
     id: "260"
     old_id: "5.06"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte" ]
-    more_people: ""
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte", "Brecht, George", "Brown, Earle", "Cage, John", "De Maria, Walter", "Ichiyanagi, Toshi", "Paik, Nam June" ]
+    more_people: [ "Flynt, Henry", "Wolff, Christian", "Riley, Terry" ]
     title: "Flyer advertising *An Anthology of Chance Operations*"
     date: "1962"
     date_sort: "1962-01-01"
@@ -4551,7 +4551,7 @@ object_list:
     id: "267"
     old_id: "5.11c"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Shiomi, Chieko", "Brecht, George", "Paik, Nam June", "Ichiyanagi, Toshi", "Knowles, Alison", "Kaprow, Allan"  ]
     more_people: ""
     title: "Artist index cards"
     date: "1961–64"
@@ -4619,8 +4619,8 @@ object_list:
     id: "271"
     old_id: "5.11e"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George", "Higgins, Dick" ]
-    more_people: ""
+    people: [ "Maciunas, George", "Higgins, Dick", "Paik, Nam June", "Knowles, Alison", "Brecht, George", "Patterson, Benjamin", "Mac Low, Jackson", "Ichiyanagi, Toshi" ]
+    more_people: [ "Watts, Robert", "Hanse, Al", "Schmit, Tomas", "Køpcke, Arthur", "Williams, Emmett", "Ligeti, Gyorgy" ]
     title: "Letters from George Maciunas to Dick Higgins"
     date: "18 January 1962 and February 1963"
     date_sort: "1962-01-18"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -9434,7 +9434,7 @@ object_list:
     id: "551"
     old_id: "10.43"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
@@ -9451,7 +9451,7 @@ object_list:
     id: "552"
     old_id: "10.44"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
@@ -9468,7 +9468,7 @@ object_list:
     id: "553"
     old_id: "10.45"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "1972"
@@ -9485,7 +9485,7 @@ object_list:
     id: "554"
     old_id: "10.46"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1974"
@@ -9502,8 +9502,8 @@ object_list:
     id: "555"
     old_id: "10.47"
     maker: [ "Dicky Bahto (American, b. 1981)" ]
-    people: [ "Bahto, Dicky" ]
-    more_people: ""
+    people: [ "Bahto, Dicky", "Shiomi, Mieko (Chieko)" ]
+    more_people: [ "Luboviski-Acosta, Tatiana", "Doran, Taylor", "Tam, Yvonne" ]
     title: "Video realization of Mieko Shiomi’s *Mirror Piece*"
     date: "1963, realized 2021"
     date_sort: "2021-01-01"
@@ -9526,7 +9526,7 @@ object_list:
     id: "556"
     old_id: "11.01a"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Mac Low, Jackson", "Kaprow, Allan", "Brecht, George", "Hansen, Al", "Higgins, Dick" ]
     more_people: ""
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, NY"
     date: "summer 1958"
@@ -9543,7 +9543,7 @@ object_list:
     id: "557"
     old_id: "11.01b"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Kaprow, Allan", "Brecht, George", "Hansen, Al" ]
     more_people: ""
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
@@ -9560,8 +9560,8 @@ object_list:
     id: "558"
     old_id: "11.01c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Higgins, Dick", "Mac Low, Jackson" ]
+    more_people: [ "Hansen, Al" ]
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
     date_sort: "1958-06-01"
@@ -9577,7 +9577,7 @@ object_list:
     id: "559"
     old_id: "11.01d"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Galente, Carol", "Addiss, Stephen", "Mac Low, Jackson" ]
     more_people: ""
     title: "Students in John Cage’s experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
@@ -9594,7 +9594,7 @@ object_list:
     id: "560"
     old_id: "11.01e"
     maker: 
-    people: ""
+    people: [ "Cage, John" ]
     more_people: ""
     title: "John Cage leading his experimental composition class, New School for Social Research, New York, New York"
     date: "summer 1958"
@@ -9696,7 +9696,7 @@ object_list:
     id: "566"
     old_id: "11.08"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan", "Johnson, Sue", "Hauck, David" ]
     more_people: ""
     title: "Allan Kaprow filming performers Sue Johnson and David Hauck for the film version of *Routine*"
     date: "1973"
@@ -9732,7 +9732,7 @@ object_list:
     old_id: "11.10"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Sullivan, Michael", "Johnson, Sue", "Hauck, David"  ]
     title: "Film still from *Routine*"
     date: "1973"
     date_sort: "1973-01-01"
@@ -9749,7 +9749,7 @@ object_list:
     old_id: "11.11"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Sullivan, Michael", "Johnson, Sue", "Hauck, David" ]
     title: "Opening shot of *Routine*"
     date: "1973"
     date_sort: "1973-01-01"
@@ -9783,7 +9783,7 @@ object_list:
     old_id: "11.14"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Kirby, Peter" ]
     title: "Opening shot of *7 Kinds of Sympathy*"
     date: "1976"
     date_sort: "1976-01-01"
@@ -9835,7 +9835,7 @@ object_list:
     old_id: "11.17"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Sullivan, Michael", "Johnson, Sue", "Hauck, David" ]
     title: "*Routine*"
     date: "1973"
     date_sort: "1973-01-01"
@@ -9852,7 +9852,7 @@ object_list:
     old_id: "11.18"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Vandrés, Galería", "Seaton, David", "Llordén, Esther", "Costas, Mario" ]
     title: "*Comfort Zones*"
     date: "1975"
     date_sort: "1975-01-01"
@@ -9869,7 +9869,7 @@ object_list:
     old_id: "11.19"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Kirby, Peter", "Steiny, Julie", "Jones, Bryan" ]
     title: "*7 Kinds of Sympathy*"
     date: "1976"
     date_sort: "1976-01-01"
@@ -9886,7 +9886,7 @@ object_list:
     old_id: "11.20"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Kirby, Peter", "Buchanan, Nancy", "Simpson, Sylvia", "Simpson, Jerry", "Rachel, Vaughn" ]
     title: "Review of using *7 Kinds of Sympathy* videotape as score"
     date: "ca. 1976"
     date_sort: "1976-01-01"
@@ -9903,7 +9903,7 @@ object_list:
     old_id: "11.21"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Kirby, Peter" ]
     title: "*Private Parts*"
     date: "1977"
     date_sort: "1977-01-01"
@@ -9987,7 +9987,7 @@ object_list:
     id: "583"
     old_id: "11.24"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan", "Cage, John" ]
     more_people: ""
     title: "Douglass College survey about the Voorhees Assembly program"
     date: "1958"
@@ -10055,7 +10055,7 @@ object_list:
     id: "587"
     old_id: "11.26c"
     maker: 
-    people: ""
+    people: [ "Burnett, Clyde", "Kaprow, Allan" ]
     more_people: ""
     title: "Allan Kaprow’s clipping of Clyde Burnett, “History of Photography Is Reviewed,” likely printed in the *Sarasota Herald-Tribune*"
     date: "1965"
@@ -10072,7 +10072,7 @@ object_list:
     id: "588"
     old_id: "11.26d"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan" ]
     more_people: ""
     title: "Notice of cancelation of Allan Kaprow’s *Soap*"
     date: "1965"
@@ -10089,7 +10089,7 @@ object_list:
     id: "589"
     old_id: "11.26e"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan", "Carter, Robert" ]
     more_people: ""
     title: "Letter from Robert Carter, a graduate student in painting at Florida State University, to Allan Kaprow"
     date: "ca. 1965"
@@ -10106,7 +10106,7 @@ object_list:
     id: "590"
     old_id: "11.26f"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan" ]
     more_people: ""
     title: "Clipping of a tidal chart of waves at Sarasota Bay, from *Soap*"
     date: "1 February 1965"
@@ -10191,7 +10191,7 @@ object_list:
     id: "595"
     old_id: "11.28"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Viggiani, Carl" ]
     more_people: ""
     title: "Contract to prepare and present a “happening,” signed by Carl A. Viggiani, chairman of the Department of Romance Languages, Wesleyan University, Middletown, Connecticut"
     date: "20 December 1967"
@@ -10208,8 +10208,8 @@ object_list:
     id: "596"
     old_id: "11.29"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Kaprow, Allan" ]
+    more_people: [ "Glantz, Andrew" ]
     title: "“Triumphal poses” of participants in Allan Kaprow’s *Transfer*"
     date: "February 1968"
     date_sort: "1968-02-01"
@@ -10242,7 +10242,7 @@ object_list:
     id: "598"
     old_id: "11.30b"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan" ]
     more_people: ""
     title: "Portland Center for the Visual Arts’ project grant application for the National Endowment for the Arts"
     date: "12 April 1973"
@@ -10250,7 +10250,7 @@ object_list:
     year_filter: [ "1973" ]
     medium: ""
     location: "Getty Research Institute, Allan Kaprow Papers, 980063, box 24, folder 9"
-    extended_caption: "It is instructive to note that the Portland Center for the Visual Arts assumed that Allam Kaprow would want to use the film budget to produce “documentation” of his event. Kaprow rejected the merely documentary function of film and did so explicitly by beginning activity booklets and films with the assertion that “this is not a record” (or another statement with a similar meaning)."
+    extended_caption: "It is instructive to note that the Portland Center for the Visual Arts assumed that Allan Kaprow would want to use the film budget to produce “documentation” of his event. Kaprow rejected the merely documentary function of film and did so explicitly by beginning activity booklets and films with the assertion that “this is not a record” (or another statement with a similar meaning)."
     credit: "Ilo Bonyhadi Estate."
     featured: 
     type: [ archival materials ]
@@ -10259,7 +10259,7 @@ object_list:
     id: "599"
     old_id: "11.30c"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Bonyhadi, Ilo" ]
     more_people: ""
     title: "Letter from Allan Kaprow to Ilo Bonyhadi, at the Portland Center for the Visual Arts"
     date: "23 April 1973"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -21,7 +21,7 @@ object_list:
     old_id: "0.01"
     maker: 
     people: ""
-    more_people: ""
+    more_people: [ "Monk, Thelonious" ]
     title: "Four “Indeterminate” Notation Systems"
     date: ""
     date_sort: ""
@@ -514,7 +514,7 @@ object_list:
     old_id: "1.12a"
     maker: [ "George W. Stowe" ]
     people: [ "Stowe, George W.", "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
-    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Varese, Edgar" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Varese, Edgard" ]
     title: "“David Tudor Program Opens Sunday Afternoon Series,” *Hartford Times*"
     date: "November 1953"
     date_sort: "1953-11-01"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -2080,7 +2080,7 @@ object_list:
     id: "121"
     old_id: "2.15ac"
     maker: [ "Louis R. Guzzo" ]
-    people: [ "Guzzo, Louis R." ]
+    people: [ "Guzzo, Louis R.", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“Cage’s Electronic Music Amazes and Amuses,” *Seattle Times*"
     date: "27 September 1962"
@@ -2097,7 +2097,7 @@ object_list:
     id: "122"
     old_id: "2.15ad"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Bernstein, Leonard", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
     more_people: ""
     title: "“Far-Out at the Philharmonic,” *Time*, 79–80"
     date: "14 February 1964"
@@ -2114,7 +2114,7 @@ object_list:
     id: "123"
     old_id: "2.16a"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Letter from John Cage to David Tudor"
     date: "29 January 1958"
@@ -2131,7 +2131,7 @@ object_list:
     id: "124"
     old_id: "2.16b"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Letter from John Cage to David Tudor"
     date: "1951"
@@ -2148,8 +2148,8 @@ object_list:
     id: "125"
     old_id: "2.16c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolpe, Stefan", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "David Tudor’s press materials"
     date: "1959?"
     date_sort: "1959-01-01"
@@ -2165,7 +2165,7 @@ object_list:
     id: "126"
     old_id: "2.16d"
     maker: [ "James Klosty" ]
-    people: [ "Klosty, James" ]
+    people: [ "Klosty, James", "Tudor, David" ]
     more_people: ""
     title: "Letter from James Klosty to David Tudor"
     date: "1971"
@@ -2182,8 +2182,8 @@ object_list:
     id: "127"
     old_id: "2.17"
     maker: [ "Mary Caroline Richards (American, 1916–99)" ]
-    people: [ "Richards, Mary Caroline" ]
-    more_people: ""
+    people: [ "Richards, Mary Caroline", "Artaud, Antonin" ]
+    more_people: 
     title: "Antonin Artaud lecture for the Living Theatre"
     date: "1959"
     date_sort: "1959-01-01"
@@ -2199,7 +2199,7 @@ object_list:
     id: "128"
     old_id: "2.18"
     maker: [ "David Tudor (American, 1926–96)", "Antonin Artaud (French, 1896–1948)" ]
-    people: [ "Tudor, David", "Artaud, Antonin" ]
+    people: [ "Tudor, David", "Artaud, Antonin", "Richards, Mary Caroline" ]
     more_people: ""
     title: "David Tudor’s typescript of M. C. Richards’s English translation of Antonin Artaud’s “An Affective Athleticism”"
     date: ""
@@ -2216,7 +2216,7 @@ object_list:
     id: "129"
     old_id: "2.19a"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor performing John Cage’s *Water Music* at Darmstadt"
     date: "1958, or possibly 1956"
@@ -2233,7 +2233,7 @@ object_list:
     id: "130"
     old_id: "2.19b"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing John Cage’s *Concert for Piano and Orchestra*"
     date: "1958"
@@ -2250,7 +2250,7 @@ object_list:
     id: "131"
     old_id: "2.19c"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "David Tudor preparing his second realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -2267,7 +2267,7 @@ object_list:
     id: "132"
     old_id: "2.19d"
     maker: [ "Manfred Leve (German, 1936–2012)" ]
-    people: [ "Leve, Manfred" ]
+    people: [ "Leve, Manfred", "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing at Galerie 22 in Düsseldorf, Germany"
     date: "14 October 1958"
@@ -2284,7 +2284,7 @@ object_list:
     id: "133"
     old_id: "2.19e"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "John Cage and David Tudor in the Tôkei-ji Temple Garden (Kanazawa, Japan)"
     date: "1962"
@@ -2301,7 +2301,7 @@ object_list:
     id: "134"
     old_id: "2.20"
     maker: 
-    people: ""
+    people: [ "Cunningham, Merce", "Cage, John" ]
     more_people: ""
     title: "Merce Cunningham conducting John Cage’s *Concert for Piano and Orchestra* at Town Hall"
     date: "15 May 1958"
@@ -2318,7 +2318,7 @@ object_list:
     id: "135"
     old_id: "2.21"
     maker: [ "Aram Avakian (American, 1926–87)" ]
-    people: [ "Avakian, Aram" ]
+    people: [ "Avakian, Aram", "Cunningham, Merce", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "John Cage, Merce Cunningham, and David Tudor at the Town Hall premiere of *Concert for Piano and Orchestra*"
     date: "May 1958"
@@ -2335,7 +2335,7 @@ object_list:
     id: "136"
     old_id: "2.22a"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Dynamics table for graph A for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2352,7 +2352,7 @@ object_list:
     id: "137"
     old_id: "2.22b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Auxiliary sound inventory for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2369,7 +2369,7 @@ object_list:
     id: "138"
     old_id: "2.22c"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the *Antic Meet* performance of John Cage’s *Solo for Piano* at the American Dance Festival"
     date: "August 1958"
@@ -2386,7 +2386,7 @@ object_list:
     id: "139"
     old_id: "2.22d"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the *Antic Meet* performance of John Cage’s *Concert for Piano and Orchestra* at the Phoenix Theatre, New York"
     date: "16 February 1960"
@@ -2403,7 +2403,7 @@ object_list:
     id: "140"
     old_id: "2.22e"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Cologne performance of John Cage’s *Solo for Piano*"
     date: "September 1958"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -10276,7 +10276,7 @@ object_list:
     id: "600"
     old_id: "11.30d"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Beebe, Mary" ]
     more_people: ""
     title: "Letter from Allan Kaprow to Mary L. Beebe at the Portland Center for the Visual Arts"
     date: "5 November 1973"
@@ -10293,8 +10293,8 @@ object_list:
     id: "601"
     old_id: "11.30e"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Kaprow, Allan", "Beebe, Mary" ]
+    more_people: [ "Sullivan, Mike" ]
     title: "Letter from Mary L. Beebe to Allan Kaprow"
     date: "21 November 1973"
     date_sort: "1973-11-21"
@@ -10379,7 +10379,7 @@ object_list:
     id: "606"
     old_id: "11.30h"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Comiter, Alvin" ]
     more_people: ""
     title: "Contact sheets of photographs by Alvin Comiter, with Allan Kaprow’s notations"
     date: "1975"
@@ -10396,7 +10396,7 @@ object_list:
     id: "607"
     old_id: "11.30i"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Sullivan, Michael", "Katz, Mel" ]
     more_people: ""
     title: "Photograph of the production crew for *Routine*"
     date: "1975"
@@ -10413,7 +10413,7 @@ object_list:
     id: "608"
     old_id: "11.30j"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Beebe, Mary", "Sullivan, Michael", "Katz, Mel" ]
     more_people: ""
     title: "Production still of *Routine*"
     date: "1975"
@@ -10430,7 +10430,7 @@ object_list:
     id: "609"
     old_id: "11.30l"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Sullivan, Michael" ]
     more_people: ""
     title: "Production still of *Routine*"
     date: "1975"
@@ -10447,7 +10447,7 @@ object_list:
     id: "610"
     old_id: "11.30m"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Sullivan, Michael" ]
     more_people: ""
     title: "Production still of *Routine*"
     date: "1975"
@@ -10464,7 +10464,7 @@ object_list:
     id: "611"
     old_id: "11.30n"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Katz, Mel" ]
     more_people: ""
     title: "Production still of *Routine*"
     date: "1975"
@@ -10515,7 +10515,7 @@ object_list:
     id: "614"
     old_id: "11.31"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Massi, Richard Wood" ]
     more_people: ""
     title: "Interview of Allan Kaprow by Richard Wood Massi, in Richard Wood Massi, *Computer, Graphic, and Traditional Systems: A Theoretical Study of Music Notation* (PhD diss., UC San Diego, 1993), 38–54"
     date: "22 June 1989"
@@ -10584,7 +10584,7 @@ object_list:
     old_id: "11.34aa"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Delford Brown, Rhett", "Delford Brown, Robert", "Eisenhauer, Letty", "Gabor, Mark", "Solow, Edie", "Gollin, Jane", "Gollin, James", "Kirby, Michael", "Kirby, Victoria", "Paik, Nam June" ]
     title: "Program for *Loss*"
     date: "1973"
     date_sort: "1973-01-01"
@@ -10600,8 +10600,8 @@ object_list:
     id: "619"
     old_id: "11.34b"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
-    more_people: ""
+    people: [ "Kaprow, Allan", "Ono, Yoko" ]
+    more_people: [ "Delford Brown, Rhett", "Delford Brown, Robert", "Paik, Nam June", "Kubota, Shigeko", "Lennon, John", "Gollin, Jane", "Gollin, James", "Eisenhauer, Letty", "Gabor, Mark" ]
     title: "List of participants and their phone numbers, for use in *Loss*"
     date: "27 January 1973"
     date_sort: "1973-01-27"
@@ -10634,7 +10634,7 @@ object_list:
     id: "621"
     old_id: "11.34d"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan" ]
     more_people: ""
     title: "Allan Kaprow’s clipping of instructions for applying Bluboro™ powder"
     date: "ca. 1973"
@@ -10651,7 +10651,7 @@ object_list:
     id: "622"
     old_id: "11.34e"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
-    people: [ "Kaprow, Allan" ]
+    people: [ "Kaprow, Allan", "Egan, Pat" ]
     more_people: ""
     title: "Letter from Allan Kaprow to Pat Egan"
     date: "18 February 1973"
@@ -10685,7 +10685,7 @@ object_list:
     id: "624"
     old_id: "11.34g"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan" ]
     more_people: ""
     title: "Contact sheet of photographs of the review session for *Loss*"
     date: "1973"
@@ -10702,7 +10702,7 @@ object_list:
     id: "625"
     old_id: "11.34h"
     maker: 
-    people: ""
+    people: [ "Kaprow, Allan", "Comiter, Alvin" ]
     more_people: ""
     title: "Contact sheet of photographs by Alvin Comiter, with Allan Kaprow’s notations"
     date: "ca. 1973"
@@ -10788,7 +10788,7 @@ object_list:
     old_id: "11.36a"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Baecker, Galerie", "Ottinger, Bee" ]
     title: "*7 Kinds of Sympathy* activity booklet"
     date: "March 1976"
     date_sort: "1976-03-01"
@@ -10805,7 +10805,7 @@ object_list:
     old_id: "11.36b"
     maker: [ "Allan Kaprow (American, 1927–2006)" ]
     people: [ "Kaprow, Allan" ]
-    more_people: ""
+    more_people: [ "Kirby, Peter" ]
     title: "Note for a videotape of *7 Kinds of Sympathy*"
     date: "March 1976"
     date_sort: "1976-03-01"
@@ -10872,7 +10872,7 @@ object_list:
     id: "348-sequence"
     old_id: "6.03a"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Maciunas, George" ]
     more_people: ""
     title: "*Water Yam*"
     date: "1963"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -3474,8 +3474,8 @@ object_list:
     id: "203"
     old_id: "4.07"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
-    people: [ "Patterson, Benjamin" ]
-    more_people: ""
+    people: [ "Patterson, Benjamin", "Mosconi, Davide", "Corner, Philip", "Neville, Phoebe", "Marchetti, Walter" ]
+    more_people:
     title: "*Paper Piece,* originally from the album *Early Works*, with Benjamin Patterson (director) and performers Davide Mosconi, Gabriele Bonomo, Philip Corner, Phoebe Neville, and Walter Marchetti (paper)"
     date: "1999"
     date_sort: "1999-01-01"
@@ -3508,7 +3508,7 @@ object_list:
     id: "205"
     old_id: "4.09"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
-    people: [ "Patterson, Benjamin" ]
+    people: [ "Patterson, Benjamin", "Knowles, Alison", "Corner, Philip", "Vautier, Ben", "Andersen, Eric", "Ritter, Willem de", "Higgins, Dick", "Williams, Emmett", "Hendricks, Geoffrey", "Klingenberg, Bent af" ]
     more_people: ""
     title: "Excerpt of *Paper Piece* performed by Ben Patterson, Ben Vautier, Alison Knowles, Eric Andersen, Willem de Ritter, Bent af Klingenberg, Philip Corner, Dick Higgins, Emmett Williams, and Geoffrey Hendricks, in Malmö, Sweden"
     date: "1992"
@@ -3526,7 +3526,7 @@ object_list:
     old_id: "4.10a"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     people: [ "Patterson, Benjamin" ]
-    more_people: ""
+    more_people: [ "Vautier, Ben" ]
     title: "Performance of *Paper Piece* in Nice, France"
     date: "1964"
     date_sort: "1964-01-01"
@@ -3543,7 +3543,7 @@ object_list:
     old_id: "4.10b"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
     people: [ "Patterson, Benjamin" ]
-    more_people: ""
+    more_people: [ "Vautier, Ben" ]
     title: "Performance of *Paper Piece* in Nice, France"
     date: "1970"
     date_sort: "1970-01-01"
@@ -3593,7 +3593,7 @@ object_list:
     id: "210"
     old_id: "4.11"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
-    people: [ "Patterson, Benjamin" ]
+    people: [ "Patterson, Benjamin", "Vostell, Wolf" ]
     more_people: ""
     title: "*Décollage Solo for Wolf Vostell*, with a letter from Wolf Vostell"
     date: "April 1960"
@@ -3730,7 +3730,7 @@ object_list:
     id: "218"
     old_id: "4.14"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
-    people: [ "Patterson, Benjamin" ]
+    people: [ "Patterson, Benjamin", "Knowles, Alison" ]
     more_people: ""
     title: "*Final Exam* for Alison Knowles"
     date: "1 June 1965"
@@ -3781,7 +3781,7 @@ object_list:
     id: "221"
     old_id: "4.17a"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Patterson, Benjamin" ]
     more_people: ""
     title: "Postcard from George Brecht to Benjamin Patterson"
     date: "22 April 1963"
@@ -3798,7 +3798,7 @@ object_list:
     id: "222"
     old_id: "4.17b"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Patterson, Benjamin" ]
     more_people: ""
     title: "Postcard from George Brecht to Benjamin Patterson"
     date: "21 January 1964"
@@ -3815,7 +3815,7 @@ object_list:
     id: "223"
     old_id: "4.17c"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Patterson, Benjamin" ]
     more_people: ""
     title: "Postcard from George Brecht to Benjamin Patterson"
     date: "7 April 1965"
@@ -3832,7 +3832,7 @@ object_list:
     id: "224"
     old_id: "4.18"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
-    people: [ "Patterson, Benjamin" ]
+    people: [ "Patterson, Benjamin", "Tudor, David" ]
     more_people: ""
     title: "Letter from Benjamin Patterson to David Tudor"
     date: "14 December 1960"
@@ -3849,7 +3849,7 @@ object_list:
     id: "225"
     old_id: "4.19"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Patterson, Benjamin" ]
     more_people: ""
     title: "Letter from George Maciunas to Benjamin Patterson"
     date: "January 1963"
@@ -3934,7 +3934,7 @@ object_list:
     id: "230"
     old_id: "4.23"
     maker: [ "Benjamin Patterson (American, 1934–2016)", "Emmett Williams (American, 1925–2007)" ]
-    people: [ "Patterson, Benjamin", "Williams, Emmett" ]
+    people: [ "Patterson, Benjamin", "Williams, Emmett", "Maciunas, George" ]
     more_people: ""
     title: "Interview with Benjamin Patterson in Emmett Williams’s “Way Way Way Out,” in *The Stars and Stripes*, 11"
     date: "30 August 1962"
@@ -3968,7 +3968,7 @@ object_list:
     id: "232"
     old_id: "4.24b"
     maker: [ "possibly Rolf Jährling" ]
-    people: [ "Jährling, Rolf" ]
+    people: [ "Jährling, Rolf", "Patterson, Benjamin" ]
     more_people: ""
     title: "Benjamin Patterson performing *Variations for Double-Bass* at *Kleinen Sommerfest: Après John Cage*, Galerie Parnass, Wuppertal, West Germany"
     date: "9 June 1962"
@@ -3985,7 +3985,7 @@ object_list:
     id: "233"
     old_id: "4.24c"
     maker: 
-    people: ""
+    people: [ "Patterson, Benjamin" ]
     more_people: ""
     title: "Performance of Benjamin Patterson’s *Paper Piece* at the Fluxus Festival, Hypokriterion Theater, Amsterdam"
     date: "23 June 1963"
@@ -4002,7 +4002,7 @@ object_list:
     id: "234"
     old_id: "4.24d"
     maker: 
-    people: ""
+    people: [ "Patterson, Benjamin", "Alphen, Oscar van" ]
     more_people: ""
     title: "Benjamin Patterson and Oscar van Alphen performing *Paper Piece* at the Fluxus Festival, Hypokriterion Theater, Amsterdam"
     date: "23 June 1963"
@@ -4019,7 +4019,7 @@ object_list:
     id: "235"
     old_id: "4.25"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Patterson, Benjamin" ]
     more_people: ""
     title: "Portrait of Benjamin Patterson"
     date: ""
@@ -4036,7 +4036,7 @@ object_list:
     id: "236"
     old_id: "4.26"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Maciunas, George", "Patterson, Benjamin" ]
     more_people: ""
     title: "Invitation and program sent to David Tudor for the exhibition *Kleinen Sommerfest: Après John Cage*, organized by George Maciunas and Benjamin Patterson at Galerie Parnass, Wuppertal, West Germany"
     date: "9 June 1962"
@@ -4053,7 +4053,7 @@ object_list:
     id: "237"
     old_id: "4.27"
     maker: [ "Manfred Leve (German, 1936–2012)" ]
-    people: [ "Leve, Manfred" ]
+    people: [ "Leve, Manfred", "Patterson, Benjamin", "Tudor, David", "Brecht, George", "Helms, Khris", "Kagel, Ursula", "Helms, Hans G." ]
     more_people: ""
     title: "Benjamin Patterson, Hans G. Helms, Ursula Kagel, Khris Helms, David Tudor, and others performing George Brecht’s *Card-Piece for Voice* (1959) as part of the “Contre-Festival,” organized during the IGNM-Weltmusikfestes, Atelier Mary Bauermeister, Cologne, Germany"
     date: "15 June 1960"
@@ -4087,8 +4087,8 @@ object_list:
     id: "239"
     old_id: "5.02a"
     maker: [ "Takehisa Kosugi (Japanese, 1938–2018)" ]
-    people: [ "Kosugi, Takehisa" ]
-    more_people: ""
+    people: [ "Kosugi, Takehisa", "Wada, Tashi" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Tashi Wada performing Kosugi’s *Micro 1* (1961) as part of the event *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4104,8 +4104,8 @@ object_list:
     id: "240"
     old_id: "5.02b"
     maker: [ "Simone Forti (American, b. 1935)" ]
-    people: [ "Forti, Simone" ]
-    more_people: ""
+    people: [ "Forti, Simone", "Wada, Tashi" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Simone Forti reading from her book *Handbook in Motion* (1974) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4121,8 +4121,8 @@ object_list:
     id: "241"
     old_id: "5.02c"
     maker: [ "Terry Riley (American, b. 1935)" ]
-    people: [ "Riley, Terry" ]
-    more_people: ""
+    people: [ "Riley, Terry", "Wada, Tashi", "Buchla, Ezra" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Ezra Buchla performing Riley’s *Ear Piece* (ca. 1962) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4138,8 +4138,8 @@ object_list:
     id: "242"
     old_id: "5.02d"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
-    more_people: ""
+    people: [ "Cage, John", "Wada, Tashi", "Holter, Julia" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Julia Holter performing Cage’s *45′ for a Speaker* (1954) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4155,8 +4155,8 @@ object_list:
     id: "243"
     old_id: "5.02e"
     maker: [ "Jackson Mac Low (American, 1922–2004)", "Simone Forti (American, b. 1935)" ]
-    people: [ "Mac Low, Jackson ", "Forti, Simone" ]
-    more_people: ""
+    people: [ "Mac Low, Jackson ", "Forti, Simone", "Wada, Tashi", "Berglund, Phoebe", "Zins-Browne, Andros" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Phoebe Berglund and Andros Zins-Browne performing Simone Forti’s dance realization of Jackson Mac Low’s *Asymmetry 222* (1980) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4175,8 +4175,8 @@ object_list:
     id: "244"
     old_id: "5.02f"
     maker: [ "Takehisa Kosugi (Japanese, 1938–2018)" ]
-    people: [ "Kosugi, Takehisa" ]
-    more_people: ""
+    people: [ "Kosugi, Takehisa", "Wada, Tashi", "Buchla, Ezra" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Ezra Buchla performing Kosugi’s *Micro 1* (1961) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4192,8 +4192,8 @@ object_list:
     id: "246"
     old_id: "5.02h"
     maker: [ "Earle Brown (American, 1926–2002)" ]
-    people: [ "Brown, Earle" ]
-    more_people: ""
+    people: [ "Brown, Earle", "Buchla, Ezra", "Wada, Tashi" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Ezra Buchla performing Brown’s *December 1952* (1952) on solo viola as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4209,8 +4209,8 @@ object_list:
     id: "247"
     old_id: "5.02i"
     maker: [ "Earle Brown (American, 1926–2002)" ]
-    people: [ "Brown, Earle" ]
-    more_people: ""
+    people: [ "Brown, Earle", "Wada, Tashi", "Muhr, Luisa", "Fogel, Corey" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Corey Fogel and Luisa Muhr performing Brown’s *December 1952* (1952) on vibraphone as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4226,8 +4226,8 @@ object_list:
     id: "248"
     old_id: "5.02j"
     maker: [ "Earle Brown (American, 1926–2002)" ]
-    people: [ "Brown, Earle" ]
-    more_people: ""
+    people: [ "Brown, Earle", "Hollander, Celia", "Wada, Tashi" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Celia Hollander performing Brown’s *December 1952* (1952) with laptop and other electronics as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4243,8 +4243,8 @@ object_list:
     id: "249"
     old_id: "5.02k"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
-    more_people: ""
+    people: [ "Brecht, George", "Fogel, Corey", "Hollander, Celia", "Holter, Julia", "Wada, Tashi" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "Corey Fogel, Celia Hollander, Julia Holter, and Tashi Wada performing George Brecht’s *Motor Vehicle Sundown (Event)* (1960) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4260,8 +4260,8 @@ object_list:
     id: "250"
     old_id: "5.02l"
     maker: [ "Simone Forti (American, b. 1935)" ]
-    people: [ "Forti, Simone" ]
-    more_people: ""
+    people: [ "Forti, Simone", "Wada, Tashi" ]
+    more_people: [ "Cooper, Sarah" ]
     title: "*Onion Walk* (1961) performed by Simone Forti and friends as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -2420,7 +2420,7 @@ object_list:
     id: "141"
     old_id: "2.22f"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Town Hall rehearsal and premiere of John Cage’s *Solo for Piano*"
     date: "15 May 1958"
@@ -2437,7 +2437,7 @@ object_list:
     id: "142"
     old_id: "2.22g"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Vienna performance of John Cage’s *Solo for Piano*"
     date: "19 November 1959"
@@ -2454,7 +2454,7 @@ object_list:
     id: "143"
     old_id: "2.22h"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Graph sequence for the Village Vanguard performance of John Cage’s *Solo for Piano*"
     date: "25 May 1958"
@@ -2471,7 +2471,7 @@ object_list:
     id: "144"
     old_id: "2.22i"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Grids and templates for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2488,7 +2488,7 @@ object_list:
     id: "145"
     old_id: "2.22j"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Index of graphs and pages from John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2505,7 +2505,7 @@ object_list:
     id: "146"
     old_id: "2.22k"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Map of graphs for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2522,7 +2522,7 @@ object_list:
     id: "147"
     old_id: "2.22l"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Notes for tape A for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2539,7 +2539,7 @@ object_list:
     id: "148"
     old_id: "2.22m"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Notes for tape B for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2556,7 +2556,7 @@ object_list:
     id: "149"
     old_id: "2.22n"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Realization fragment for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2573,7 +2573,7 @@ object_list:
     id: "150"
     old_id: "2.22o"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Reverse sequence of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2590,7 +2590,7 @@ object_list:
     id: "151"
     old_id: "2.22p"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Sketch of the graph sequence for the Cologne performance of John Cage’s *Solo for Piano*"
     date: "September 1958"
@@ -2607,7 +2607,7 @@ object_list:
     id: "152"
     old_id: "2.22q"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Unidentified sequence sketch for the first realization of John Cage’s *Solo for Piano*"
     date: "1958"
@@ -2624,7 +2624,7 @@ object_list:
     id: "153"
     old_id: "2.22r"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Unidentified sketches for the first realization of John Cage’s *Solo for Piano*"
     date: "May 1958"
@@ -2641,7 +2641,7 @@ object_list:
     id: "154"
     old_id: "3.01"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "David Tudor’s personal copy of Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2658,7 +2658,7 @@ object_list:
     id: "155"
     old_id: "3.02"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Typed instructions (in Italian and German) for Sylvano Bussotti’s *Five Pieces for David Tudor*"
     date: "1959"
@@ -2675,7 +2675,7 @@ object_list:
     id: "156"
     old_id: "3.03a"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s realization of *No. 1* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2692,7 +2692,7 @@ object_list:
     id: "157"
     old_id: "3.03b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s realization of *No. 4* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2709,7 +2709,7 @@ object_list:
     id: "158"
     old_id: "3.04"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s realization of *No. 3* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2726,7 +2726,7 @@ object_list:
     id: "159"
     old_id: "3.05"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Loose score sheets for Sylvano Bussotti’s *Pièces de chair II*"
     date: "1958–60"
@@ -2794,7 +2794,7 @@ object_list:
     id: "163"
     old_id: "3.08"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "David Tudor’s tables and sketches for his realizations of *No. 4* from Sylvano Bussotti’s *Five Piano Pieces for David Tudor*"
     date: "1959"
@@ -2811,7 +2811,7 @@ object_list:
     id: "164"
     old_id: "3.09"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Performance note for *No. 5* from *Piano Pieces for David Tudor*"
     date: "1959"
@@ -2862,7 +2862,7 @@ object_list:
     id: "167"
     old_id: "3.11b"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "25 August 1967"
@@ -2879,7 +2879,7 @@ object_list:
     id: "168"
     old_id: "3.11d"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Envelope from Sylvano Bussotti to David Tudor"
     date: "1959"
@@ -2896,7 +2896,7 @@ object_list:
     id: "169"
     old_id: "3.11e"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Ink drawing by Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -2930,7 +2930,7 @@ object_list:
     id: "171"
     old_id: "3.11g"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Envelope from Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -2947,7 +2947,7 @@ object_list:
     id: "172"
     old_id: "3.11h"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Signature on score fragment to David Tudor"
     date: "1959"
@@ -2964,7 +2964,7 @@ object_list:
     id: "173"
     old_id: "3.11i"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Ink drawing by Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -2998,7 +2998,7 @@ object_list:
     id: "175"
     old_id: "3.11k"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Miscellaneous scores by Sylvano Bussotti sent to David Tudor"
     date: "1959(?)"
@@ -3015,7 +3015,7 @@ object_list:
     id: "176"
     old_id: "3.11l"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Postcard from Sylvano Bussotti to David Tudor"
     date: "6 January 1965"
@@ -3032,7 +3032,7 @@ object_list:
     id: "177"
     old_id: "3.11m"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "25 April 1965"
@@ -3049,7 +3049,7 @@ object_list:
     id: "178"
     old_id: "3.11n"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "2 November 1959"
@@ -3066,7 +3066,7 @@ object_list:
     id: "179"
     old_id: "3.11o"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "24 May 1967"
@@ -3083,7 +3083,7 @@ object_list:
     id: "180"
     old_id: "3.11p"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "n.d."
@@ -3100,7 +3100,7 @@ object_list:
     id: "181"
     old_id: "3.11q"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Letter from Sylvano Bussotti to David Tudor"
     date: "22 May 1959"
@@ -3108,7 +3108,7 @@ object_list:
     year_filter: [ "1959" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 51, folder 8"
-    extended_caption: "This is the letter Sylvano Bussotti included with his initial package of scores to DavidTudor. It makes explicit the high level of trust the composer has in the performer’s ability to realize his scores."
+    extended_caption: "This is the letter Sylvano Bussotti included with his initial package of scores to David Tudor. It makes explicit the high level of trust the composer has in the performer’s ability to realize his scores."
     credit: "Courtesy of the Sylvano Bussotti Estate."
     featured: 
     type: [ correspondence ]
@@ -3117,7 +3117,7 @@ object_list:
     id: "182"
     old_id: "3.12"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Postcard from Sylvano Bussotti and other avant-garde composers to David Tudor"
     date: "1959"
@@ -3134,8 +3134,8 @@ object_list:
     id: "183"
     old_id: "3.13a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Cage, John" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Musica d’Oggi, Conservatorio B. Marcello, Concerto del pianista David Tudor; *Nos. 5, 2*, and *3* from Sylvano Bussotti’s *Piano Pieces for David Tudor*"
     date: "12 November 1959"
     date_sort: "1959-11-12"
@@ -3151,8 +3151,8 @@ object_list:
     id: "184"
     old_id: "3.13b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Cardew, Cornelius", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Centro d’Arte degli Studenti dell’Università di Padova, 266 Concerto, David Tudor pianista, Sylvano Bussotti, *Piano Pieces for David Tudor*"
     date: "14 November 1959"
     date_sort: "1959-11-14"
@@ -3168,8 +3168,8 @@ object_list:
     id: "185"
     old_id: "3.13c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "Program from a Wesleyan University piano recital"
     date: "24 April 1961"
     date_sort: "1961-04-24"
@@ -3185,8 +3185,8 @@ object_list:
     id: "186"
     old_id: "3.14a"
     maker: [ "U. D." ]
-    people: ""
-    more_people: ""
+    people: [ "Bussotti, Sylvano", "Cage, John", "Tudor, David" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz" ]
     title: "“Concerto di Tudor a Venezia,” *L’Unità*, 4"
     date: "13 November 1959"
     date_sort: "1959-11-13"
@@ -3202,8 +3202,8 @@ object_list:
     id: "187"
     old_id: "3.14b"
     maker: [ "Lodovico Mamprin" ]
-    people: [ "Mamprin, Lodovico" ]
-    more_people: ""
+    people: [ "Mamprin, Lodovico", "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz" ]
     title: "“Tre concerti in Italia di musiche d’avanguardia,” *Giornale del Mattino*, 5"
     date: "15 November 1959"
     date_sort: "1959-11-15"
@@ -3219,8 +3219,8 @@ object_list:
     id: "188"
     old_id: "3.14c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Young, La Monte" ]
+    more_people: [ "Wolff, Christian" ]
     title: "“David Tudor Series Set,” *New York Times*"
     date: "8 March 1960"
     date_sort: "1960-03-08"
@@ -3236,7 +3236,7 @@ object_list:
     id: "189"
     old_id: "3.14d"
     maker: [ "Paul Henry Lang" ]
-    people: [ "Lang, Paul Henry" ]
+    people: [ "Lang, Paul Henry", "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "“Long-Hair Critic Reviews a Glove-Wearing Pianist,” *New York Herald Tribune*"
     date: "29 March 1960"
@@ -3253,8 +3253,8 @@ object_list:
     id: "190"
     old_id: "3.14e"
     maker: [ "Eric Salzman" ]
-    people: [ "Salzman, Eric" ]
-    more_people: ""
+    people: [ "Salzman, Eric", "Tudor, David", "Bussotti, Sylvano" ]
+    more_people: [ "Cardew, Cornelius", "Stockhausen, Karlheinz" ]
     title: "“Recital Is Given by David Tudor,” *New York Times*"
     date: "29 March 1960"
     date_sort: "1960-03-29"
@@ -3270,7 +3270,7 @@ object_list:
     id: "191"
     old_id: "3.14f"
     maker: [ "Ed Wallace" ]
-    people: [ "Wallace, Ed" ]
+    people: [ "Wallace, Ed", "Tudor, David", "Bussotti, Sylvano" ]
     more_people: ""
     title: "“War on the Keys: Above Ground Test Deactivates Piano,” *New York World-Telegram and Sun*"
     date: "5 April 1960"
@@ -3287,8 +3287,8 @@ object_list:
     id: "192"
     old_id: "3.14g"
     maker: [ "Harold C. Schonberg" ]
-    people: [ "Schonberg, Harold C." ]
-    more_people: ""
+    people: [ "Schonberg, Harold C.", "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Feldman, Morton" ]
+    more_people: [ "Boulez, Pierre" ]
     title: "“The Far-Out Pianist,” *Harper’s Magazine*, 49–54"
     date: "June 1960"
     date_sort: "1960-06-01"
@@ -3304,7 +3304,7 @@ object_list:
     id: "193"
     old_id: "3.14h"
     maker: [ "Enrique Franco" ]
-    people: [ "Franco, Enrique" ]
+    people: [ "Franco, Enrique", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“David Tudor presenta un programa de musica experimental: Jean Martinon dirige La Nacional,” 21"
     date: "12 November 1960"
@@ -3321,8 +3321,8 @@ object_list:
     id: "194"
     old_id: "3.14i"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Cage, John" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "“Musikken der fik TV-Seerne til at Storme Radiohuset: Er den gale musik kun skruptosset?,” *Politiken*, 13"
     date: "30 July 1961"
     date_sort: "1961-07-30"
@@ -3338,7 +3338,7 @@ object_list:
     id: "195"
     old_id: "3.15"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Lecture notes on David Tudor’s performance practice as a pianist during the late 1950s and early ’60s"
     date: "early 1960s"
@@ -3355,7 +3355,7 @@ object_list:
     id: "196"
     old_id: "3.16"
     maker: [ "Manfred Leve (German, 1936–2012)" ]
-    people: [ "Leve, Manfred" ]
+    people: [ "Leve, Manfred", "Tudor, David" ]
     more_people: ""
     title: "David Tudor performing with gloves"
     date: "ca. 1959"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -9094,8 +9094,8 @@ object_list:
     id: "531"
     old_id: "10.23"
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
-    people: [ "Shiomi, Mieko (Chieko)" ]
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George", "Brecht, George", "Ichiyanagi, Toshi" ]
+    more_people: [ "Kosugi, Takehisa", "Zazeela, Marian" ]
     title: "“Mieko Shiomi,” *Art and Artists* 8, no. 7 (1973): 42–45"
     date: ""
     date_sort: ""
@@ -9128,7 +9128,7 @@ object_list:
     id: "533"
     old_id: "10.25"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1963"
@@ -9145,7 +9145,7 @@ object_list:
     id: "534"
     old_id: "10.26"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "fall 1965"
@@ -9162,8 +9162,8 @@ object_list:
     id: "535"
     old_id: "10.27"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
+    more_people: [ "Flynt, Henry" ]
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1965"
     date_sort: "1965-01-01"
@@ -9179,7 +9179,7 @@ object_list:
     id: "536"
     old_id: "10.28"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1965"
@@ -9196,8 +9196,8 @@ object_list:
     id: "537"
     old_id: "10.29"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
+    more_people: [ "Finlay, Ian Hamilton" ]
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "1966"
     date_sort: "1966-01-01"
@@ -9213,7 +9213,7 @@ object_list:
     id: "538"
     old_id: "10.30"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
@@ -9230,7 +9230,7 @@ object_list:
     id: "539"
     old_id: "10.31"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas, with annotations by Maciunas"
     date: "ca. 1966"
@@ -9247,7 +9247,7 @@ object_list:
     id: "540"
     old_id: "10.32"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "1966"
@@ -9264,8 +9264,8 @@ object_list:
     id: "541"
     old_id: "10.33"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
+    more_people: [ "Johns, Jasper" ]
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
     date_sort: "1966-01-01"
@@ -9281,7 +9281,7 @@ object_list:
     id: "542"
     old_id: "10.34"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
@@ -9298,7 +9298,7 @@ object_list:
     id: "543"
     old_id: "10.35"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1966"
@@ -9315,8 +9315,8 @@ object_list:
     id: "544"
     old_id: "10.36"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
+    more_people: [ "Brown, Jean" ]
     title: "Letter from Mieko (Chieko) Shiomi to George Maciunas"
     date: "ca. 1968"
     date_sort: "1968-01-01"
@@ -9332,7 +9332,7 @@ object_list:
     id: "545"
     old_id: "10.37"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Postcard from Mieko Shiomi to George Maciunas"
     date: "ca. 1968"
@@ -9349,7 +9349,7 @@ object_list:
     id: "546"
     old_id: "10.38"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1968"
@@ -9366,7 +9366,7 @@ object_list:
     id: "547"
     old_id: "10.39"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1971"
@@ -9383,7 +9383,7 @@ object_list:
     id: "548"
     old_id: "10.40"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Postcard from Mieko Shiomi to George Maciunas"
     date: "1971"
@@ -9400,7 +9400,7 @@ object_list:
     id: "549"
     old_id: "10.41"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"
@@ -9417,7 +9417,7 @@ object_list:
     id: "550"
     old_id: "10.42"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Mieko Shiomi to George Maciunas"
     date: "ca. 1972"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -514,7 +514,7 @@ object_list:
     old_id: "1.12a"
     maker: [ "George W. Stowe" ]
     people: [ "Stowe, George W.", "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
-    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Varese, Edgard" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Varese, Edgar" ]
     title: "“David Tudor Program Opens Sunday Afternoon Series,” *Hartford Times*"
     date: "November 1953"
     date_sort: "1953-11-01"
@@ -3203,7 +3203,7 @@ object_list:
     old_id: "3.14b"
     maker: [ "Lodovico Mamprin" ]
     people: [ "Mamprin, Lodovico", "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
-    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz", "Amey, Frank", "Evangelisti, Franco" ]
     title: "“Tre concerti in Italia di musiche d’avanguardia,” *Giornale del Mattino*, 5"
     date: "15 November 1959"
     date_sort: "1959-11-15"
@@ -3321,8 +3321,8 @@ object_list:
     id: "194"
     old_id: "3.14i"
     maker: 
-    people: [ "Tudor, David", "Bussotti, Sylvano", "Cage, John" ]
-    more_people: [ "Stockhausen, Karlheinz" ]
+    people: [ "Tudor, David", "Bussotti, Sylvano", "Cage, John", "Karlheinz, Stockhausen" ]
+    more_people: ""
     title: "“Musikken der fik TV-Seerne til at Storme Radiohuset: Er den gale musik kun skruptosset?,” *Politiken*, 13"
     date: "30 July 1961"
     date_sort: "1961-07-30"
@@ -4104,8 +4104,8 @@ object_list:
     id: "240"
     old_id: "5.02b"
     maker: [ "Simone Forti (American, b. 1935)" ]
-    people: [ "Forti, Simone", "Wada, Tashi" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Forti, Simone" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Simone Forti reading from her book *Handbook in Motion* (1974) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4121,8 +4121,8 @@ object_list:
     id: "241"
     old_id: "5.02c"
     maker: [ "Terry Riley (American, b. 1935)" ]
-    people: [ "Riley, Terry", "Wada, Tashi", "Buchla, Ezra" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Riley, Terry", "Buchla, Ezra" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Ezra Buchla performing Riley’s *Ear Piece* (ca. 1962) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4138,8 +4138,8 @@ object_list:
     id: "242"
     old_id: "5.02d"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John", "Wada, Tashi", "Holter, Julia" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Cage, John", "Holter, Julia" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Julia Holter performing Cage’s *45′ for a Speaker* (1954) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4155,8 +4155,8 @@ object_list:
     id: "243"
     old_id: "5.02e"
     maker: [ "Jackson Mac Low (American, 1922–2004)", "Simone Forti (American, b. 1935)" ]
-    people: [ "Mac Low, Jackson ", "Forti, Simone", "Wada, Tashi", "Berglund, Phoebe", "Zins-Browne, Andros" ]
-    more_people: [ "Cooper, Sarah", "Paxton, Steve" ]
+    people: [ "Mac Low, Jackson ", "Forti, Simone", "Berglund, Phoebe", "Zins-Browne, Andros" ]
+    more_people: [ "Cooper, Sarah", "Paxton, Steve", "Wada, Tashi" ]
     title: "Phoebe Berglund and Andros Zins-Browne performing Simone Forti’s dance realization of Jackson Mac Low’s *Asymmetry 222* (1980) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4175,8 +4175,8 @@ object_list:
     id: "244"
     old_id: "5.02f"
     maker: [ "Takehisa Kosugi (Japanese, 1938–2018)" ]
-    people: [ "Kosugi, Takehisa", "Wada, Tashi", "Buchla, Ezra" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Kosugi, Takehisa", "Buchla, Ezra" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Ezra Buchla performing Kosugi’s *Micro 1* (1961) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4192,8 +4192,8 @@ object_list:
     id: "246"
     old_id: "5.02h"
     maker: [ "Earle Brown (American, 1926–2002)" ]
-    people: [ "Brown, Earle", "Buchla, Ezra", "Wada, Tashi" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Brown, Earle", "Buchla, Ezra" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Ezra Buchla performing Brown’s *December 1952* (1952) on solo viola as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4209,8 +4209,8 @@ object_list:
     id: "247"
     old_id: "5.02i"
     maker: [ "Earle Brown (American, 1926–2002)" ]
-    people: [ "Brown, Earle", "Wada, Tashi", "Muhr, Luisa", "Fogel, Corey" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Brown, Earle", "Muhr, Luisa", "Fogel, Corey" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Corey Fogel and Luisa Muhr performing Brown’s *December 1952* (1952) on vibraphone as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4226,8 +4226,8 @@ object_list:
     id: "248"
     old_id: "5.02j"
     maker: [ "Earle Brown (American, 1926–2002)" ]
-    people: [ "Brown, Earle", "Hollander, Celia", "Wada, Tashi" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Brown, Earle", "Hollander, Celia" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "Celia Hollander performing Brown’s *December 1952* (1952) with laptop and other electronics as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4260,8 +4260,8 @@ object_list:
     id: "250"
     old_id: "5.02l"
     maker: [ "Simone Forti (American, b. 1935)" ]
-    people: [ "Forti, Simone", "Wada, Tashi" ]
-    more_people: [ "Cooper, Sarah" ]
+    people: [ "Forti, Simone" ]
+    more_people: [ "Cooper, Sarah", "Wada, Tashi" ]
     title: "*Onion Walk* (1961) performed by Simone Forti and friends as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4345,8 +4345,8 @@ object_list:
     id: "255"
     old_id: "5.03"
     maker: 
-    people: [ "Brecht, George", "Brown, Earle", "Cage, John", "Young, La Monte", "De Maria, Walter", "Ono, Yoko" ]
-    more_people: [ "Higgins, Dick", "Flynt, Henry", "Ichiyanagi, Toshi" ]
+    people: [ "Brecht, George", "Brown, Earle", "Cage, John", "Young, La Monte", "Ono, Yoko", "Ichiyanagi, Toshi" ]
+    more_people: [ "Higgins, Dick", "Flynt, Henry", "De Maria, Walter" ]
     title: "Program from a fundraising concert for *An Anthology of Chance Operations* at the Living Theatre, New York, NY"
     date: "8 January 1962"
     date_sort: "1962-01-08"
@@ -4379,7 +4379,7 @@ object_list:
     id: "257"
     old_id: "5.05a"
     maker: 
-    people: [ "Young, La Monte", "Ono, Yoko" ]
+    people: [ "Young, La Monte", "Ono, Yoko", "Maxfield, Richard", "Tudor, David" ]
     more_people: 
     title: "Flyer for “Three Evenings of Picnic and Electronic Music by Richard Maxfield,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "28–30 April 1961"
@@ -4415,7 +4415,7 @@ object_list:
     old_id: "5.05c"
     maker: 
     people: [ "Young, La Monte", "Ono, Yoko" ]
-    more_people: ""
+    more_people: [ "Dunn, Robert", "Morris, Robert" ]
     title: "Program for “Compositions by La Monte Young,” part of the concert series organized by Yoko Ono and Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "19–20 May 1961"
     date_sort: "1961-05-19"
@@ -4432,8 +4432,8 @@ object_list:
     id: "260"
     old_id: "5.06"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte", "Brecht, George", "Brown, Earle", "Cage, John", "De Maria, Walter", "Ichiyanagi, Toshi", "Paik, Nam June" ]
-    more_people: [ "Flynt, Henry", "Wolff, Christian", "Riley, Terry" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte", "Brecht, George", "Brown, Earle", "Cage, John", "Ichiyanagi, Toshi" ]
+    more_people: [ "Flynt, Henry", "Wolff, Christian", "Riley, Terry", "De Maria, Walter", "Paik, Nam June" ]
     title: "Flyer advertising *An Anthology of Chance Operations*"
     date: "1962"
     date_sort: "1962-01-01"
@@ -4551,8 +4551,8 @@ object_list:
     id: "267"
     old_id: "5.11c"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George", "Mac Low, Jackson", "Shiomi, Chieko", "Brecht, George", "Paik, Nam June", "Ichiyanagi, Toshi", "Knowles, Alison", "Kaprow, Allan"  ]
-    more_people: ""
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Shiomi, Chieko", "Brecht, George", "Ichiyanagi, Toshi", "Knowles, Alison", "Kaprow, Allan"  ]
+    more_people: [ "Paik, Nam June" ]
     title: "Artist index cards"
     date: "1961–64"
     date_sort: "1961-01-01"
@@ -4619,8 +4619,8 @@ object_list:
     id: "271"
     old_id: "5.11e"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George", "Higgins, Dick", "Paik, Nam June", "Knowles, Alison", "Brecht, George", "Patterson, Benjamin", "Mac Low, Jackson", "Ichiyanagi, Toshi" ]
-    more_people: [ "Watts, Robert", "Hanse, Al", "Schmit, Tomas", "Køpcke, Arthur", "Williams, Emmett", "Ligeti, Gyorgy" ]
+    people: [ "Maciunas, George", "Higgins, Dick", "Knowles, Alison", "Brecht, George", "Patterson, Benjamin", "Mac Low, Jackson", "Ichiyanagi, Toshi" ]
+    more_people: [ "Watts, Robert", "Hanse, Al", "Schmit, Tomas", "Køpcke, Arthur", "Williams, Emmett", "Ligeti, Gyorgy", "Paik, Nam June" ]
     title: "Letters from George Maciunas to Dick Higgins"
     date: "18 January 1962 and February 1963"
     date_sort: "1962-01-18"
@@ -4687,7 +4687,7 @@ object_list:
     id: "275"
     old_id: "5.12d"
     maker: 
-    people: [ "Mac Low, Jackson", "Ono, Yoko", "Young, La Monte" ]
+    people: [ "Mac Low, Jackson", "Ono, Yoko", "Young, La Monte", "Ichiyanagi, Toshi" ]
     more_people: ""
     title: "Program for *Poetry, Music, and Theatre Works: Jackson Mac Low*, the fifth concert in the series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "8–9 April 1961"
@@ -4704,8 +4704,8 @@ object_list:
     id: "276"
     old_id: "5.12e"
     maker: 
-    people: [ "Mac Low, Jackson", "Neuhaus, Max", "Tenney, James", "Patterson, Benjamin" ]
-    more_people: [ "Corner, Philip" ]
+    people: [ "Mac Low, Jackson", "Patterson, Benjamin" ]
+    more_people: [ "Corner, Philip", "Neuhaus, Max", "Tenney, James" ]
     title: "Bifold program for “A Program of Electronic Music, Electronic Poetry & Live Simultaneities,” held at Town Hall, New York, NY"
     date: "13 September 1966"
     date_sort: "1966-09-13"
@@ -4721,8 +4721,8 @@ object_list:
     id: "277"
     old_id: "5.13a"
     maker: [ "Remy Charlip (American, 1929–2012)" ]
-    people: [ "Charlip, Remy", "Tudor, David", "Bussotti, Sylvano", "Young, La Monte", "Cage, John" ]
-    more_people: [ "Pousseur, Henri", "Ichiyanagi, Toshi", "Stockhausen, Karlheinz", "Cardew, Cornelius" ]
+    people: [ "Charlip, Remy", "Tudor, David", "Bussotti, Sylvano", "Young, La Monte", "Cage, John", "Ichiyanagi, Toshi" ]
+    more_people: [ "Pousseur, Henri", "Stockhausen, Karlheinz", "Cardew, Cornelius" ]
     title: "Flyer for recitals by David Tudor at the Living Theatre, New York, NY"
     date: "March–April 1960"
     date_sort: "1960-03-01"
@@ -4875,8 +4875,8 @@ object_list:
     id: "286"
     old_id: "5.13k"
     maker: [ "Ray Johnson (American, 1927–95)" ]
-    people: [ "Johnson, Ray", "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Young, La Monte" ]
-    more_people: [ "Stockhausen, Karlheinz", "Pousseur, Henri", "Cardew, Cornelius", "Ichiyanagi, Toshi" ]
+    people: [ "Johnson, Ray", "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Young, La Monte", "Ichiyanagi, Toshi" ]
+    more_people: [ "Stockhausen, Karlheinz", "Pousseur, Henri", "Cardew, Cornelius" ]
     title: "Collage created from a flyer designed by Remy Charlip for recitals by David Tudor at the Living Theatre, New York, NY, plus an envelope"
     date: "ca. 1960"
     date_sort: "1960-01-01"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -6153,7 +6153,7 @@ object_list:
     id: "360"
     old_id: "6.13"
     maker: 
-    people: ""
+    people: [ "Maciunas, George", "Brecht, George" ]
     more_people: ""
     title: "George Maciunas performing George Brecht’s *Drip Music (Drip Event)* (1959–62) at *Festum Fluxorum*, at Kunstakademie Düsseldorf, Düsseldorf, Germany"
     date: "2 February 1963"
@@ -6170,7 +6170,7 @@ object_list:
     id: "361"
     old_id: "6.14"
     maker: 
-    people: ""
+    people: [ "Maciunas, George", "Brecht, George", "Paik, Nam June", "Schmit, Tomas", "Klintberg, Bengt af", "Williams, Emmett", "Trowbridge, Frank", "Köpcke, Arthur", "Spoerri, Daniel" ]
     more_people: ""
     title: "Ensemble performance of George Brecht’s *Drip Music (Drip Event)* (1959–62), directed by George Maciunas at *Festum Fluxorum*, at Kunstakademie Düsseldorf, Düsseldorf, Germany"
     date: "2 February 1963"
@@ -6187,8 +6187,8 @@ object_list:
     id: "362"
     old_id: "6.15"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Moore, Peter", "Brecht, George" ]
+    more_people: [ "Hansen, Al" ]
     title: "George Brecht performing *Three Aqueous Events/Drip Music (Drip Event)* (1959–62) at the concert *Happenings, Events, and Advanced Musics*, at Douglass College, Rutgers University, New Brunswick, NJ"
     date: "6 April 1963"
     date_sort: "1963-04-06"
@@ -6204,7 +6204,7 @@ object_list:
     id: "363"
     old_id: "6.16"
     maker: 
-    people: ""
+    people: [ "Brecht, George", "Vautier, Ben" ]
     more_people: ""
     title: "Sculptural realization of George Brecht’s *Drip Music (Drip Event)* (1959–62) at the New York Fluxhall/Fluxshop, New York, NY"
     date: "1964"
@@ -6221,8 +6221,8 @@ object_list:
     id: "364"
     old_id: "6.17"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Brecht, George", "Kaprow, Allan", "Cage, John" ]
+    more_people: [ "Cernovich, Nicola", "Waring, James", "Rauschenberg, Robert", "Johnson, Ray", "Maxfield, Richard", "Hansen, Al" ]
     title: "Program for *A Concert of New Music*, Living Theatre, New York, NY"
     date: "14 March 1960"
     date_sort: "1960-03-14"
@@ -6238,8 +6238,8 @@ object_list:
     id: "365"
     old_id: "6.18"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Brecht, George", "Kaprow, Allan", "Cage, John" ]
+    more_people: [ "Cernovich, Nicola", "Waring, James", "Rauschenberg, Robert", "Maxfield, Richard", "Hansen, Al" ]
     title: "Flyer for *A Concert of New Music*, Living Theatre, New York, NY, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 4 (Cologne: Walther König, 1998), 230"
     date: "14 March 1960"
     date_sort: "1960-03-14"
@@ -6308,7 +6308,7 @@ object_list:
     id: "369"
     old_id: "6.22a"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Brecht, George" ]
     more_people: ""
     title: "Letter from George Maciunas to George Brecht"
     date: "ca. January 1963"
@@ -6394,7 +6394,7 @@ object_list:
     id: "374"
     old_id: "6.24"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David" ]
     more_people: ""
     title: "*Eight Piano Transcriptions (for David Tudor)*"
     date: "1963"
@@ -6411,7 +6411,7 @@ object_list:
     id: "375"
     old_id: "6.25"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David" ]
     more_people: ""
     title: "Letter from George Brecht to David Tudor"
     date: "11 July 1961"
@@ -6428,7 +6428,7 @@ object_list:
     id: "376"
     old_id: "6.26"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David" ]
     more_people: ""
     title: "*Incidental Music*, event score sent to David Tudor"
     date: "summer 1961"
@@ -6445,7 +6445,7 @@ object_list:
     id: "377"
     old_id: "6.27"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Brecht, George" ]
     more_people: ""
     title: "Handwritten and typed transcriptions of George Brecht event scores"
     date: "ca. 1962–63"
@@ -6462,7 +6462,7 @@ object_list:
     id: "378"
     old_id: "6.28"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David" ]
     more_people: ""
     title: "*Event (Pulse Start, Pulse Stop)*, event score sent to David Tudor"
     date: "December 1962"
@@ -6479,7 +6479,7 @@ object_list:
     id: "379"
     old_id: "6.29"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "*Motor Vehicle Sundown (Event)*, event score sent to David Tudor"
     date: "spring/summer 1960"
@@ -6496,7 +6496,7 @@ object_list:
     id: "380"
     old_id: "6.30"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David" ]
     more_people: ""
     title: "*Three Aqueous Events*, event score sent to David Tudor"
     date: "summer 1961"
@@ -6513,7 +6513,7 @@ object_list:
     id: "381"
     old_id: "6.31"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David" ]
     more_people: ""
     title: "*Three Chair Events*, event score sent to David Tudor"
     date: "spring 1961"
@@ -6530,7 +6530,7 @@ object_list:
     id: "382"
     old_id: "6.32"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Brecht, George" ]
     more_people: ""
     title: "Audio recording of a performance of George Brecht’s *Incidental Music* (summer 1961) at the Kongresssaal Mathildenhöhe, Darmstadt, Germany, as part of the 1961 Internationale Ferienkurse für Neue Musik"
     date: "6 September 1961"
@@ -6547,8 +6547,8 @@ object_list:
     id: "383"
     old_id: "6.33"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Patterson, Benjamin", "Brecht, George" ]
+    more_people: [ "Clavez, Bertrand" ]
     title: "Benjamin Patterson recording his realization of George Brecht’s *Drip Music (Drip Event)* (1959–62) in Paris using a specially made apparatus designed by Patterson with the assistance of Bertrand Clavez"
     date: "2002"
     date_sort: "2002-01-01"
@@ -6564,7 +6564,7 @@ object_list:
     id: "384"
     old_id: "6.34"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Cage, John" ]
     more_people: ""
     title: "Notebook page, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 2 (Cologne: Walther König, 1991), 35–36"
     date: "26 October 1958"
@@ -6581,7 +6581,7 @@ object_list:
     id: "385"
     old_id: "6.35"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Cage, John" ]
     more_people: ""
     title: "Notebook page, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 2 (Cologne: Walther König, 1991), 64–66"
     date: "ca. December 1958"
@@ -6650,8 +6650,8 @@ object_list:
     id: "389"
     old_id: "6.39"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
-    more_people: ""
+    people: [ "Brecht, George", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
     title: "Notebook page, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 3 (Cologne: Walther König, 1991), 123"
     date: "ca. late July 1959"
     date_sort: "1959-07-15"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -2828,7 +2828,7 @@ object_list:
     id: "165"
     old_id: "3.10"
     maker: [ "Sylvano Bussotti (Italian, 1931–2021)" ]
-    people: [ "Bussotti, Sylvano" ]
+    people: [ "Bussotti, Sylvano", "Tudor, David" ]
     more_people: ""
     title: "Performance notes for Sylvano Bussotti’s *Pièces de chair II*"
     date: "1958–59"
@@ -4156,7 +4156,7 @@ object_list:
     old_id: "5.02e"
     maker: [ "Jackson Mac Low (American, 1922–2004)", "Simone Forti (American, b. 1935)" ]
     people: [ "Mac Low, Jackson ", "Forti, Simone", "Wada, Tashi", "Berglund, Phoebe", "Zins-Browne, Andros" ]
-    more_people: [ "Cooper, Sarah" ]
+    more_people: [ "Cooper, Sarah", "Paxton, Steve" ]
     title: "Phoebe Berglund and Andros Zins-Browne performing Simone Forti’s dance realization of Jackson Mac Low’s *Asymmetry 222* (1980) as part of *Meaningless Work, Get to Work*, curated by Sarah Cooper and Tashi Wada"
     date: "4 December 2021"
     date_sort: "2021-12-04"
@@ -4687,7 +4687,7 @@ object_list:
     id: "275"
     old_id: "5.12d"
     maker: 
-    people: ""
+    people: [ "Mac Low, Jackson", "Ono, Yoko", "Young, La Monte" ]
     more_people: ""
     title: "Program for *Poetry, Music, and Theatre Works: Jackson Mac Low*, the fifth concert in the series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "8–9 April 1961"
@@ -4704,8 +4704,8 @@ object_list:
     id: "276"
     old_id: "5.12e"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Mac Low, Jackson", "Neuhaus, Max", "Tenney, James", "Patterson, Benjamin" ]
+    more_people: [ "Corner, Philip" ]
     title: "Bifold program for “A Program of Electronic Music, Electronic Poetry & Live Simultaneities,” held at Town Hall, New York, NY"
     date: "13 September 1966"
     date_sort: "1966-09-13"
@@ -4721,8 +4721,8 @@ object_list:
     id: "277"
     old_id: "5.13a"
     maker: [ "Remy Charlip (American, 1929–2012)" ]
-    people: [ "Charlip, Remy" ]
-    more_people: ""
+    people: [ "Charlip, Remy", "Tudor, David", "Bussotti, Sylvano", "Young, La Monte", "Cage, John" ]
+    more_people: [ "Pousseur, Henri", "Ichiyanagi, Toshi", "Stockhausen, Karlheinz", "Cardew, Cornelius" ]
     title: "Flyer for recitals by David Tudor at the Living Theatre, New York, NY"
     date: "March–April 1960"
     date_sort: "1960-03-01"
@@ -4739,8 +4739,8 @@ object_list:
     id: "278"
     old_id: "5.13b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Bussotti, Sylvano" ]
+    more_people: [ "Stockhausen, Karlheinz", "Cardew, Cornelius" ]
     title: "Program for a recital by David Tudor at the Living Theatre, New York, NY"
     date: "28 March 1960"
     date_sort: "1960-03-28"
@@ -4756,8 +4756,8 @@ object_list:
     id: "279"
     old_id: "5.13c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Program for a recital by David Tudor at the Living Theatre, New York, NY"
     date: "4 April 1960"
     date_sort: "1960-04-04"
@@ -4773,8 +4773,8 @@ object_list:
     id: "280"
     old_id: "5.13d"
     maker: 
-    people: ""
-    more_people: ""
+    people: [" Tudor, David", "Ichiyanagi, Toshi", "Young, La Monte", "Cage, John", "Cunningham, Merce" ]
+    more_people: [ "Cardew, Cornelius", "Wolff, Christian" ]
     title: "Program for a recital by David Tudor and Toshi Ichiyanagi at the Living Theatre, New York, NY"
     date: "11 April 1960"
     date_sort: "1960-04-11"
@@ -4790,7 +4790,7 @@ object_list:
     id: "281"
     old_id: "5.13f"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David", "Ichiyanagi, Toshi", "Kobayashi, Kenji" ]
     more_people: ""
     title: "Program for a Composers’ Showcase concert featuring the music of John Cage performed by Cage, David Tudor, Toshi Ichiyanagi, and Kenji Kobayashi, Museum of Modern Art, New York, NY"
     date: "20 April 1961"
@@ -4807,7 +4807,7 @@ object_list:
     id: "282"
     old_id: "5.13g"
     maker: 
-    people: ""
+    people: [ "Ichiyanagi, Toshi", "Ono, Yoko", "Cage, John", "Tudor, David", "Young, La Monte", "Cunningham, Merce", "Mac Low, Jackson" ]
     more_people: ""
     title: "Flyer for “Music by Toshi Ichiyanagi,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "7–8 January 1961"
@@ -4824,7 +4824,7 @@ object_list:
     id: "283"
     old_id: "5.13h"
     maker: 
-    people: ""
+    people: [ "Ichiyanagi, Toshi", "Young, La Monte", "Ono, Yoko", "Mac Low, Jackson", "Tudor, David", "Cage, John", "Cunningham, Merce" ]
     more_people: ""
     title: "Program for “Music by Toshi Ichiyanagi,” part of the concert series organized by Yoko Ono and La Monte Young at Ono’s studio, 112 Chambers Street, New York, NY"
     date: "7–8 January 1961"
@@ -4841,7 +4841,7 @@ object_list:
     id: "284"
     old_id: "5.13i"
     maker: 
-    people: ""
+    people: [ "Mayuzumi, Toshiro", "Ono, Yoko", "Ichiyanagi, Toshi", "Cage, John", "Young, La Monte", "Forti, Simone", "Tudor, David" ]
     more_people: ""
     title: "Program for a concert of “Contemporary Japanese Music & Poetry” by Toshiro Mayuzumi, Toshi Ichiyanagi, and Yoko Ono, performed by Mayazumi, Ichiyanagi, Ono, John Cage, La Monte Young, Simone Forti, David Tudor, and others at the Village Gate, New York, NY"
     date: "3 April 1961"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -8516,7 +8516,7 @@ object_list:
     id: "497"
     old_id: "9.23"
     maker: 
-    people: [ "Knowles, Alison", "Lockwood, Anna", "Shiomi, Mieko", "Forti, Simone" ]
+    people: [ "Knowles, Alison", "Lockwood, Anna", "Shiomi, Mieko (Chieko)", "Forti, Simone" ]
     more_people: [ "Oliveros, Pauline" ]
     title: "Announcement for *Womens Work*, “a magazine of performance scores by contemporary women artists”"
     date: ""
@@ -8584,7 +8584,7 @@ object_list:
     id: "501"
     old_id: "9.27"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Maciunas, George" ]
     more_people: ""
     title: "Letter from Alison Knowles to George Maciunas about macrobiotic diets"
     date: ""
@@ -8601,7 +8601,7 @@ object_list:
     id: "502"
     old_id: "9.28"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Williams, Emmett" ]
     more_people: ""
     title: "Note from Alison Knowles to Emmett Williams on verso of “Wheat Hearts” cardboard label"
     date: ""
@@ -8618,7 +8618,7 @@ object_list:
     id: "503"
     old_id: "9.29a"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Williams, Emmett", "Patterson, Benjamin" ]
     more_people: ""
     title: "Letter from Alison Knowles to [Oscar] Emmett Williams"
     date: "April ca. 1963"
@@ -8635,8 +8635,8 @@ object_list:
     id: "504"
     old_id: "9.29b"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
-    more_people: ""
+    people: [ "Knowles, Alison", "Williams, Emmett", "Brecht, George", "Kaprow, Allan", "Brown, Earle" ]
+    more_people: [ "Hansen, Al", "Watts, Robert" ]
     title: "Letter from Alison Knowles to [Oscar] Emmett Williams"
     date: "n.d. (ca. 1963)"
     date_sort: "1963-01-01"
@@ -8652,8 +8652,8 @@ object_list:
     id: "505"
     old_id: "9.29c"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
-    more_people: ""
+    people: [ "Knowles, Alison", "Williams, Emmett", "Brecht, George", "Mac Low, Jackson", "Maciunas, George" ]
+    more_people: [ "Watts, Robert" ]
     title: "Letter from Alison Knowles to [Oscar] Emmett Williams"
     date: "n.d. [“Saturday night,” ca. 1963]"
     date_sort: "1963-01-01"
@@ -8669,7 +8669,7 @@ object_list:
     id: "506"
     old_id: "9.30"
     maker: 
-    people: ""
+    people: [ "Knowles, Alison" ]
     more_people: ""
     title: "Alison Knowles tasting soup"
     date: ""
@@ -8755,7 +8755,7 @@ object_list:
     old_id: "9.35"
     maker: [ "Alison Knowles (American, b. 1933)" ]
     people: [ "Knowles, Alison" ]
-    more_people: ""
+    more_people: [ "Williams, Emmett", "Corner, Philip" ]
     title: "*Journal of the Identical Lunch* (San Francisco: Nova Broadcast Press, 1971)"
     date: ""
     date_sort: ""
@@ -8771,7 +8771,7 @@ object_list:
     id: "512"
     old_id: "9.36"
     maker: [ "Philip Corner (American, b. 1933)" ]
-    people: [ "Corner, Philip" ]
+    people: [ "Corner, Philip", "Knowles, Alison" ]
     more_people: ""
     title: "*The Identical Lunch* (San Francisco: Nova Broadcast Press, 1973)"
     date: ""
@@ -8788,8 +8788,8 @@ object_list:
     id: "513"
     old_id: "9.37"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
-    more_people: ""
+    people: [ "Maciunas, George", "Knowles, Alison", "Mac Low, Jackson", "Patterson, Benjamin", "Young, La Monte" ]
+    more_people: [ "Flynt, Henry", "Higgins, Dick", "Paik, Nam June", "Zazeela, Marian", "Alloway, Lawrence", "Williams, Emmett" ]
     title: "“Invitation to Participate in New Years Eve’s Flux-Feast”"
     date: "1969"
     date_sort: "1969-01-01"
@@ -8822,8 +8822,8 @@ object_list:
     id: "515"
     old_id: "10.01"
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
-    people: [ "Shiomi, Mieko (Chieko)" ]
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Maciunas, George", "Brecht, George", "Cage, John", "Kaprow, Allan", "Knowles, Alison", "Mac Low, Jackson", "Patterson, Benjamin", "Young, La Monte" ]
+    more_people: [ "Corner, Philip", "Ginsberg, Allan", "Finlay, Ian Hamilton", "Higgins, Dick", "Kosugi, Takehisa", "Ligeti, Gyorgy", "Paik, Nam June", "Schneemann, Carolee", "Vautier, Ben", "Vostell, Wolf", "Zazeela, Marian" ]
     title: "List of participants in *Spatial Poem (Nos. 1–4)*"
     date: "ca. 1972"
     date_sort: "1972-01-01"
@@ -8856,7 +8856,7 @@ object_list:
     id: "517"
     old_id: "10.03"
     maker: 
-    people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Kaprow, Allan" ]
     more_people: ""
     title: "Mieko Shiomi performing *Direction Music for Fingers* at Washington Square Gallery, New York, NY"
     date: "30 October 1964"
@@ -8873,8 +8873,8 @@ object_list:
     id: "518"
     old_id: "10.10"
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
-    people: [ "Shiomi, Mieko (Chieko)" ]
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Kaprow, Allan", "Maciunas, George", "Brecht, George", "Cage, John", "Kaprow, Allan", "Knowles, Alison", "Mac Low, Jackson", "Patterson, Benjamin", "Young, La Monte" ]
+    more_people: [ "Corner, Philip", "Ginsberg, Allan", "Finlay, Ian Hamilton", "Higgins, Dick", "Kosugi, Takehisa", "Ligeti, Gyorgy", "Paik, Nam June", "Schneemann, Carolee", "Vautier, Ben", "Vostell, Wolf", "Zazeela, Marian" ]
     title: "Promotional postcard for *Complete Works: Spatial Poem*"
     date: "ca. 1976"
     date_sort: "1976-01-01"
@@ -9077,8 +9077,8 @@ object_list:
     id: "530"
     old_id: "10.22"
     maker: [ "Mieko (Chieko) Shiomi (Japanese, b. 1938)" ]
-    people: [ "Shiomi, Mieko (Chieko)" ]
-    more_people: ""
+    people: [ "Shiomi, Mieko (Chieko)", "Kaprow, Allan", "Maciunas, George", "Brecht, George", "Cage, John", "Kaprow, Allan", "Knowles, Alison", "Mac Low, Jackson", "Patterson, Benjamin", "Young, La Monte" ]
+    more_people: [ "Corner, Philip", "Ginsberg, Allan", "Finlay, Ian Hamilton", "Higgins, Dick", "Kosugi, Takehisa", "Ligeti, Gyorgy", "Paik, Nam June", "Schneemann, Carolee", "Vautier, Ben", "Vostell, Wolf", "Zazeela, Marian" ]
     title: "Cover of *Spatial Poem* (Osaka: self-published, 1976)"
     date: ""
     date_sort: ""

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -5148,7 +5148,7 @@ object_list:
     id: "302"
     old_id: "5.17b"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Brown, Earle" ]
     more_people: ""
     title: "A Realization of Earle Brown’s *December 1952*"
     date: "1950s"
@@ -5216,7 +5216,7 @@ object_list:
     id: "306"
     old_id: "5.18d"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "*Music for Piano No. 4 (for David Tudor)*"
     date: "December 1960"
@@ -5233,7 +5233,7 @@ object_list:
     id: "307"
     old_id: "5.18e"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Ichiyanagi, Toshi" ]
     more_people: ""
     title: "Notes for a realization of Toshi Ichiyanagi’s *Music for Piano No. 4 (for David Tudor)*"
     date: "ca. late 1960"
@@ -5250,7 +5250,7 @@ object_list:
     id: "308"
     old_id: "5.18f"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "*Music for Piano No. 5 (for David Tudor)*"
     date: "December 1960"
@@ -5267,7 +5267,7 @@ object_list:
     id: "309"
     old_id: "5.18g"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Riley, Terry" ]
     more_people: ""
     title: "*Music for Piano No. 6 (for Terry Riley)*"
     date: "January 1961"
@@ -5301,7 +5301,7 @@ object_list:
     id: "311"
     old_id: "5.18i"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Ichiyanagi, Toshi" ]
     more_people: ""
     title: "Electronic processing diagram for Toshi Ichiyanagi’s *Activities for Orchestra*, for Merce Cunningham’s dance *Scramble*"
     date: "1967"
@@ -5335,7 +5335,7 @@ object_list:
     id: "313"
     old_id: "5.19"
     maker: [ "Christian Wolff (American, b. 1934)" ]
-    people: [ "Wolff, Christian" ]
+    people: [ "Wolff, Christian", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "*Duet I*, with notes sent to John Cage and David Tudor"
     date: "1960"
@@ -5352,7 +5352,7 @@ object_list:
     id: "314"
     old_id: "5.27a"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "25 September 1961"
@@ -5369,7 +5369,7 @@ object_list:
     id: "315"
     old_id: "5.27b"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "10 March 1962"
@@ -5386,7 +5386,7 @@ object_list:
     id: "316"
     old_id: "5.27c"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "17 April 1962"
@@ -5403,7 +5403,7 @@ object_list:
     id: "317"
     old_id: "5.27d"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "September, ca. 1962"
@@ -5421,8 +5421,8 @@ object_list:
     id: "318"
     old_id: "5.27e"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
-    more_people: ""
+    people: [ "Ichiyanagi, Toshi", "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Feldman, Morton" ]
+    more_people: [ "Boulez, Pierre", "Wolff, Christian", "Stockhausen, Karlheinz" ]
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "20 November 1962"
     date_sort: "1962-11-20"
@@ -5438,7 +5438,7 @@ object_list:
     id: "319"
     old_id: "5.27f"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "15 February 1963"
@@ -5455,8 +5455,8 @@ object_list:
     id: "320"
     old_id: "5.27g"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
-    more_people: ""
+    people: [ "Ichiyanagi, Toshi", "Tudor, David", "Young, La Monte", "Cage, John", "Brecht, George", "Ono, Yoko" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "19 December 1963"
     date_sort: "1963-12-19"
@@ -5472,7 +5472,7 @@ object_list:
     id: "321"
     old_id: "5.27h"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Tudor, David" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to David Tudor"
     date: "4 February 1967"
@@ -5489,7 +5489,7 @@ object_list:
     id: "322"
     old_id: "5.28"
     maker: [ "La Monte Young (American, b. 1935)" ]
-    people: [ "Young, La Monte" ]
+    people: [ "Young, La Monte", "Flynt, Henry" ]
     more_people: ""
     title: "*X for Henry Flynt*"
     date: "April 1960"
@@ -5543,7 +5543,7 @@ object_list:
     id: "325"
     old_id: "5.29c"
     maker: [ "Terry Jennings (American, 1940–81)" ]
-    people: [ "Jennings, Terry" ]
+    people: [ "Jennings, Terry", "Tudor, David" ]
     more_people: ""
     title: "*Piece for Violins, Violas, and Sopranino Saxophone*"
     date: "January 1963"
@@ -5596,7 +5596,7 @@ object_list:
     id: "328"
     old_id: "5.29f"
     maker: [ "Terry Jennings (American, 1940–81)" ]
-    people: [ "Jennings, Terry" ]
+    people: [ "Jennings, Terry", "Tudor, David" ]
     more_people: ""
     title: "*Piano Piece*"
     date: "December 1958"
@@ -5632,7 +5632,7 @@ object_list:
     id: "330"
     old_id: "5.30"
     maker: [ "Warner Jepson (1930–2011)" ]
-    people: [ "Jepson, Warner" ]
+    people: [ "Jepson, Warner", "Tudor, David" ]
     more_people: ""
     title: "Letter from Warner Jepson to David Tudor"
     date: "1960"
@@ -5701,8 +5701,8 @@ object_list:
     id: "334"
     old_id: "5.34a"
     maker: [ "Paul Henry Lang" ]
-    people: [ "Lang, Paul Henry" ]
-    more_people: ""
+    people: [ "Lang, Paul Henry", "Tudor, David", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Higgins, Dick" ]
     title: "Review of a performance by David Tudor and the Audio-Visual Group, *New York Herald Tribune*"
     date: "8 April 1959"
     date_sort: "1959-04-08"
@@ -5718,8 +5718,8 @@ object_list:
     id: "335"
     old_id: "5.34b"
     maker: [ "Harold C. Schonberg" ]
-    people: [ "Schonberg, Harold C." ]
-    more_people: ""
+    people: [ "Schonberg, Harold C.", "Tudor, David", "Cage, John" ]
+    more_people: [ "Higgins, Dick", "Hansen, Al", "Wolff, Christian" ]
     title: "“‘Advanced’ Music Beeps and Plinks: Experimenters Use Bottle, Ratchets, Toy Machine Gun in Concert at ‘Y,’” review of David Tudor and the Audio-Visual Group, *New York Times*"
     date: "8 April 1959"
     date_sort: "1959-04-08"
@@ -5735,7 +5735,7 @@ object_list:
     id: "336"
     old_id: "5.34c"
     maker: [ "George Gelles" ]
-    people: [ "Gelles, George" ]
+    people: [ "Gelles, George", "Tudor, David", "Lucier, Alvin", "Ichiyanagi, Toshi", "Cage, John" ]
     more_people: ""
     title: "“Electronic Concert Not Very Amusing,” review of a David Tudor and Alvin Lucier performance of works by Alvin Lucier, Toshi Ichiyanagi, and John Cage, *Boston Globe*"
     date: "27 February 1966"
@@ -5752,7 +5752,7 @@ object_list:
     id: "337"
     old_id: "5.34d"
     maker: [ "Anthony Matejczyk" ]
-    people: [ "Matejczyk, Anthony" ]
+    people: [ "Matejczyk, Anthony", "Cage, John", "Ichiyanagi, Toshi", "Lucier, Alvin", "Tudor, David" ]
     more_people: ""
     title: "“Music for Our Time: Gurgles and Growls,” review of a David Tudor and Alvin Lucier performance of works by Alvin Lucier, Toshi Ichiyanagi, and John Cage, *Boston Herald*"
     date: "ca. February 1966"
@@ -5769,8 +5769,8 @@ object_list:
     id: "338"
     old_id: "5.34e"
     maker: [ "Nancy K. Siff" ]
-    people: [ "Siff, Nancy K." ]
-    more_people: ""
+    people: [ "Siff, Nancy K.", "Tudor, David" ]
+    more_people: [ "Wolff, Christian", "Hansen, Al" ]
     title: "“Pong Bong,” review of a performance by David Tudor and the Audio-Visual Group, *The Village Voice*"
     date: "15 April 1959"
     date_sort: "1959-04-15"
@@ -5786,7 +5786,7 @@ object_list:
     id: "339"
     old_id: "5.34f"
     maker: [ "Ross Parmenter" ]
-    people: [ "Parmenter, Ross" ]
+    people: [ "Parmenter, Ross", "Mayuzumi, Toshiro", "Ono, Yoko", "Ichiyanagi, Toshi", "Cage, John", "Young, La Monte", "Forti, Simone", "Tudor, David" ]
     more_people: ""
     title: "“Music: Far Out Program; Contemporary Japanese Offering at the Village Gate Proves Unusual Fare,” review of a concert of “Contemporary Japanese Music & Poetry” by Toshiro Mayuzumi, Toshi Ichiyanagi, and Yoko Ono, performed by Mayazumi, Ichiyanagi, Ono, John Cage, La Monte Young, Simone Forti, David Tudor, and others at the Village Gate, New York, NY, *New York Times*"
     date: "4 April 1961"
@@ -5804,7 +5804,7 @@ object_list:
     old_id: "5.34g"
     maker: [ "Francis D. Perkins" ]
     people: [ "Perkins, Francis D." ]
-    more_people: ""
+    more_people: [ "Tudor, David", "Maxfield, Richard", "Cage, John", "Otto, Hans", "Kayn, Roland" ]
     title: "“David Tudor Plays Piano at Social Research School,” review of a recital by David Tudor of works by Richard Maxfield, John Cage, Hans Otto, and Roland Kayn at the New School for Social Research, New York, NY, *New York Tribune*"
     date: "24 March 1961"
     date_sort: "1961-03-24"
@@ -5820,8 +5820,8 @@ object_list:
     id: "341"
     old_id: "5.35"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Higgins, Dick", "Tudor, David", "Patterson, Benjamin", "Knowles, Alison", "Brecht, George", "Young, La Monte" ]
+    more_people: [ "Hansen, Al" ]
     title: "Concert program for *Happenings, Events, and Advanced Musics*, at Douglass College, Rutgers University, New Brunswick, NJ, sent by Dick Higgins to David Tudor"
     date: "6 April 1963"
     date_sort: "1963-04-06"
@@ -5837,8 +5837,8 @@ object_list:
     id: "342"
     old_id: "5.36"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
-    more_people: ""
+    people: [ "Maciunas, George", "Tudor, David", "Young, La Monte" ]
+    more_people: [ "Flynt, Henry", "De Maria, Walter" ]
     title: "Concert flyer for “Mvsica Antiqva et Nova Presents Evenings at AG,” sent to David Tudor from unknown sender"
     date: "1961"
     date_sort: "1961-01-01"
@@ -5854,7 +5854,7 @@ object_list:
     id: "343"
     old_id: "5.37"
     maker: [ "Matsuzaki Kunitoshi" ]
-    people: [ "Kunitoshi, Matsuzaki" ]
+    people: [ "Kunitoshi, Matsuzaki", "Cage, John", "Tudor, David", "Ono, Yoko", "Toshiro, Mayuzumi" ]
     more_people: ""
     title: "John Cage’s *Music Walk* (1958), performed by John Cage, David Tudor, Yoko Ono, and Mayuzumi Toshirō, at Tokyo Bunka Kaikan Hall, Tokyo, Japan"
     date: "9 October 1962"
@@ -5949,7 +5949,7 @@ object_list:
     id: "348"
     old_id: "6.03a"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Maciunas, George" ]
     more_people: ""
     title: "*Water Yam*"
     date: "1963"
@@ -5983,7 +5983,7 @@ object_list:
     id: "350"
     old_id: "6.03c"
     maker: 
-    people: ""
+    people: [ "Brecht, George" ]
     more_people: ""
     title: "High-speed video of the unboxing and repacking of George Brecht’s compendium of event scores, *Water Yam* (1963)"
     date: ""
@@ -6000,7 +6000,7 @@ object_list:
     id: "351"
     old_id: "6.04"
     maker: [ "Benjamin Patterson (American, 1934–2016)" ]
-    people: [ "Patterson, Benjamin" ]
+    people: [ "Patterson, Benjamin", "Brecht, George" ]
     more_people: ""
     title: "*Drip Music* (1959), from the album *George Brecht/Ben Patterson: Drip Music/370 Flies*, Alga Marghen (record label), Milan, Italy, 2002"
     date: "recorded 2002"
@@ -6017,8 +6017,8 @@ object_list:
     id: "352"
     old_id: "6.05"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Brecht, George", "Patterson, Benjamin", "Barbereau, Johan", "Spolidor, Fleur", "Costantini, Gilles" ]
+    more_people: [ "Clavez, Bertrand", "Clavez, Claudia" ]
     title: "Benjamin Patterson (director), performance of George Brecht’s *Drip Music (Drip Event)* (1959–62), at Ménagerie de Verre, Paris"
     date: "18 June 2002"
     date_sort: "2002-06-18"
@@ -6034,7 +6034,7 @@ object_list:
     id: "353"
     old_id: "6.06"
     maker: 
-    people: ""
+    people: [ "Higgins, Dick", "Brecht, George", "Miller, Larry" ]
     more_people: ""
     title: "Dick Higgins performing George Brecht’s *Drip Music (Drip Event)* (1959–62), The Kitchen, New York, NY; excerpted from the film *Flux Concert*, directed by Larry Miller (1979)"
     date: "24 March 1979"
@@ -6051,7 +6051,7 @@ object_list:
     id: "354"
     old_id: "6.07"
     maker: 
-    people: ""
+    people: [ "Brecht, George", "Garvin, Perry", "Knowles, Alison" ]
     more_people: ""
     title: "Perry Garvin performing George Brecht’s *Drip Music (Drip Event)* (1959–62), Triskelion Arts, Brooklyn, NY, part of *FLUXCONCERT 20090220-21: two evening performances of event scores written by Fluxus pioneer George Brecht*"
     date: "20 February 2009"
@@ -6068,8 +6068,8 @@ object_list:
     id: "355"
     old_id: "6.08"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Kubota, Midori" ]
+    more_people: [ "Matsuo, Rina", "Araki, Konomi", "Akagi, Chikae", "Tsurufusa, Saika" ]
     title: "Midori Kubota and students performing George Brecht’s *Drip Music (Drip Event)* (1959–62), at Kobe College, Hyogo, Japan, directed by Midori Kubota"
     date: "2 November 2015"
     date_sort: "2015-11-02"
@@ -6085,7 +6085,7 @@ object_list:
     id: "356"
     old_id: "6.09"
     maker: 
-    people: ""
+    people: [ "Byrd, Joseph", "Williams, Emmett", "Patterson, Benjamin", "Paik, Nam June", "Young, La Monte", "Corner, Philip" ]
     more_people: ""
     title: "Archival film-to-video transfer of a 1962 German newsreel reporting on Fluxus Internationale Festspiele Neuester Musik, Wiesbaden, West Germany, Hessenschau television news program (broadcast by Hessischer Rundfunk)"
     date: "11 September 1962"
@@ -6102,7 +6102,7 @@ object_list:
     id: "357"
     old_id: "6.10"
     maker: 
-    people: ""
+    people: [ "Brecht, George" ]
     more_people: ""
     title: "Google.com video search for “‘George Brecht’ ‘Drip Music’”"
     date: ""
@@ -6119,8 +6119,8 @@ object_list:
     id: "358"
     old_id: "6.11"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Knowles, Alison", "Corner, Philip", "Forti, Simone", "Brecht, George", "Ichiyanagi, Toshi", "Ono, Yoko", "Patterson, Benjamin", "Shiomi, Chieko", "Young, La Monte" ]
+    more_people: [ "Friedman, Ken", "Miller, Larry", "Wada, Yoshi", "Higgins, Dick", "Kosugi, Takehisa", "Paik, Nam June" ]
     title: "Press release for *FLUXUS: Classic ’60’s Performances Plus the Premier of Alison Knowles’ “Natural Assemblages and the True Crow”* at The Kitchen, New York, NY"
     date: "24 March 1979"
     date_sort: "1979-03-24"
@@ -6136,7 +6136,7 @@ object_list:
     id: "359"
     old_id: "6.12"
     maker: 
-    people: ""
+    people: [ "Higgins, Dick", "Brecht, George" ]
     more_people: ""
     title: "Dick Higgins performing George Brecht’s *Drip Music (Drip Event)* (1959–62) at Fluxus–Musik og Anti Musik det Instrumentale Teater, Nikolai Kirke, Copenhagen, Denmark"
     date: "23 November 1962"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1332,7 +1332,7 @@ object_list:
     id: "077"
     old_id: "2.09"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David", "Cage, John" ]
+    people: [ "Tudor, David", "Cage, John", "Oliveros, Pauline", "Subotnick, Morton" ]
     more_people: ""
     title: "Live performance of the first realization of John Cage’s *Concert for Piano and Orchestra* at Mills College"
     date: "1964"
@@ -1451,8 +1451,8 @@ object_list:
     id: "084"
     old_id: "2.14b"
     maker: 
-    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
-    more_people: [ "Ajemian, Maro", "Richards, Mary Caroline" ]
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David", "Richards, Mary Caroline" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "Press release for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1612,7 +1612,7 @@ object_list:
     year_filter: [ "1961" ]
     medium: ""
     location: "Getty Research Institute, David Tudor Papers, 980039, box 63, folder 5"
-    extended_caption: "The author of this mock review collages together a [*Harper’s Magazine* feature article on Davod Tudor](/image-index/192/), and includes a score reproduction, commentary on Tudor’s work, information about the performance, and a note about the virtues of Photostat-based typography. Though he seems not to have attended the concert, the writer’s observations about Tudor’s work (presumably based on the *Harper’s* article) exemplify the tendency of middlebrow critics to engage in their own armchair philosophizing about the upending of traditional ontologies of music. The author calls Tudor’s performance an indeterminate “thing,” and compares experimental notation to a tradition of formalized diagraming that is more familiar but equally complex—a football playbook."
+    extended_caption: "The author of this mock review collages together a [*Harper’s Magazine* feature article on David Tudor](/image-index/192/), and includes a score reproduction, commentary on Tudor’s work, information about the performance, and a note about the virtues of Photostat-based typography. Though he seems not to have attended the concert, the writer’s observations about Tudor’s work (presumably based on the *Harper’s* article) exemplify the tendency of middlebrow critics to engage in their own armchair philosophizing about the upending of traditional ontologies of music. The author calls Tudor’s performance an indeterminate “thing,” and compares experimental notation to a tradition of formalized diagraming that is more familiar but equally complex—a football playbook."
     credit: ""
     featured: 
     type: [ programs and flyers ]
@@ -1621,8 +1621,8 @@ object_list:
     id: "094"
     old_id: "2.15a"
     maker: [ "H. G." ]
-    people: [ "Tudor, David", "Cage, John" ]
-    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
+    people: [ "Tudor, David", "Cage, John", "Stockhausen, Karlheinz" ]
+    more_people: [ "Boulez, Pierre" ]
     title: "“Mäßiger Auftakt in Köln: Drei Premieren, darunter eine mit Wäscheklammern,” *Neue Rhein Zeitung*"
     date: "25 September 1958"
     date_sort: "1958-09-25"
@@ -1638,7 +1638,7 @@ object_list:
     id: "095"
     old_id: "2.15b"
     maker: [ "Dore Ashton" ]
-    people: [ "Ashton, Dore", "Cage, John" ]
+    people: [ "Ashton, Dore", "Cage, John", "Rauschenberg, Robert", "Johns, Jasper" ]
     more_people: ""
     title: "“Cage, Composer, Shows Calligraphy of Note,” review of the Stable Gallery show, *New York Times*"
     date: "6 May 1958"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -4858,7 +4858,7 @@ object_list:
     id: "285"
     old_id: "5.13j"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "Program for a piano recital by David Tudor at the New School for Social Research, New York, NY"
     date: "24 March 1961"
@@ -4875,8 +4875,8 @@ object_list:
     id: "286"
     old_id: "5.13k"
     maker: [ "Ray Johnson (American, 1927–95)" ]
-    people: [ "Johnson, Ray" ]
-    more_people: ""
+    people: [ "Johnson, Ray", "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Young, La Monte" ]
+    more_people: [ "Stockhausen, Karlheinz", "Pousseur, Henri", "Cardew, Cornelius", "Ichiyanagi, Toshi" ]
     title: "Collage created from a flyer designed by Remy Charlip for recitals by David Tudor at the Living Theatre, New York, NY, plus an envelope"
     date: "ca. 1960"
     date_sort: "1960-01-01"
@@ -4893,7 +4893,7 @@ object_list:
     id: "287"
     old_id: "5.13l"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Flyer for concert by John Cage and David Tudor at the Living Theatre, New York, NY"
     date: "25 January 1960"
@@ -4910,7 +4910,7 @@ object_list:
     id: "288"
     old_id: "5.14a"
     maker: 
-    people: ""
+    people: [ "Young, La Monte", "Mac Low, Jackson", "Maciunas, George" ]
     more_people: ""
     title: "Miniature mock-up for *An Anthology of Chance Operations* with handwritten notes, probably by Jackson Mac Low, George Maciunas, and La Monte Young"
     date: "ca. 1962"
@@ -4927,7 +4927,7 @@ object_list:
     id: "289"
     old_id: "5.14b"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*"
     date: "1 December 1961"
@@ -4944,7 +4944,7 @@ object_list:
     id: "290"
     old_id: "5.14c"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*"
     date: "20 February 1962"
@@ -4961,7 +4961,7 @@ object_list:
     id: "291"
     old_id: "5.14d"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson", "Young, La Monte" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*"
     date: "13 May 1962"
@@ -4978,7 +4978,7 @@ object_list:
     id: "292"
     old_id: "5.14e"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*"
     date: "22 August 1962"
@@ -4995,7 +4995,7 @@ object_list:
     id: "293"
     old_id: "5.14f"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*"
     date: "August 1962"
@@ -5012,7 +5012,7 @@ object_list:
     id: "294"
     old_id: "5.14g"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*"
     date: "October 1962"
@@ -5046,7 +5046,7 @@ object_list:
     id: "296"
     old_id: "5.14i"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson" ]
     more_people: ""
     title: "Chart of artistic movements and media including optic, acoustic, kinetic, and semantic/symbolic arts, mailed by George Maciunas to Jackson Mac Low"
     date: "ca. 1961–62"
@@ -5063,7 +5063,7 @@ object_list:
     id: "297"
     old_id: "5.14j"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Mac Low, Jackson" ]
     more_people: ""
     title: "Letter from George Maciunas to Jackson Mac Low on *An Anthology of Chance Operations*, written on the back of *Fluxus News leter [sic] No. 5*"
     date: "January 1963"
@@ -5080,7 +5080,7 @@ object_list:
     id: "298"
     old_id: "5.14k"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
+    people: [ "Maciunas, George", "Young, La Monte" ]
     more_people: ""
     title: "Letter from George Maciunas to La Monte Young on *An Anthology of Chance Operations*"
     date: ""
@@ -5097,7 +5097,7 @@ object_list:
     id: "299"
     old_id: "5.16a"
     maker: [ "La Monte Young (American, b. 1935)" ]
-    people: [ "Young, La Monte" ]
+    people: [ "Young, La Monte", "Tudor, David" ]
     more_people: ""
     title: "Letter from La Monte Young to David Tudor"
     date: "1960–61"
@@ -5114,7 +5114,7 @@ object_list:
     id: "300"
     old_id: "5.16b"
     maker: [ "La Monte Young (American, b. 1935)" ]
-    people: [ "Young, La Monte" ]
+    people: [ "Young, La Monte", "Tudor, David" ]
     more_people: ""
     title: "Letter from La Monte Young to David Tudor"
     date: "1960–61"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -7372,8 +7372,8 @@ object_list:
     id: "430"
     old_id: "7.34"
     maker: [ "Peter Zummo" ]
-    people: [ "Zummo, Peter" ]
-    more_people: ""
+    people: [ "Zummo, Peter", "Mac Low, Jackson" ]
+    more_people: [ "Corner, Philip" ]
     title: "“Words: Jackson Mac Low, The Brook,” *Soho Weekly News*"
     date: "8 April 1976"
     date_sort: "1976-04-08"
@@ -7389,7 +7389,7 @@ object_list:
     id: "431"
     old_id: "7.35"
     maker: [ "Tom Johnson" ]
-    people: [ "Johnson, Tom" ]
+    people: [ "Johnson, Tom", "Mac Low, Jackson", "Cage, John" ]
     more_people: ""
     title: "“A Mac Low High Point,” *The Village Voice*"
     date: "6 October 1982"
@@ -7406,7 +7406,7 @@ object_list:
     id: "432"
     old_id: "7.36"
     maker: [ "Robert Palmer" ]
-    people: [ "Palmer, Robert" ]
+    people: [ "Palmer, Robert", "Jackson, Mac Low" ]
     more_people: ""
     title: "“Music: Perplexities of Fluxus,” *New York Times*"
     date: "2 June 1978"
@@ -7423,7 +7423,7 @@ object_list:
     id: "433"
     old_id: "7.37"
     maker: [ "Tom Johnson" ]
-    people: [ "Johnson, Tom" ]
+    people: [ "Johnson, Tom", "Mac Low, Jackson", "Cage, John" ]
     more_people: ""
     title: "“Jackson Mac Low: Text Sound Pieces,” *The Village Voice*"
     date: "28 April 1975"
@@ -7440,7 +7440,7 @@ object_list:
     id: "434"
     old_id: "7.38"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Tudor, David" ]
     more_people: ""
     title: "Letter from Jackson Mac Low to David Tudor"
     date: "30 March 1961"
@@ -7457,7 +7457,7 @@ object_list:
     id: "435"
     old_id: "7.39"
     maker: 
-    people: ""
+    people: [ "Mac Low, Jackson" ]
     more_people: ""
     title: "Photograph of Jackson Mac Low"
     date: "25 January 1965"
@@ -7543,7 +7543,7 @@ object_list:
     old_id: "8.06"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     people: [ "Rainer, Yvonne" ]
-    more_people: ""
+    more_people: [ "Banes, Sally" ]
     title: "*Trio A* (1966), produced by Sally Banes"
     date: "1978"
     date_sort: "1978-01-01"
@@ -7559,7 +7559,7 @@ object_list:
     id: "441"
     old_id: "8.07"
     maker: ""
-    people: ""
+    people: [ "Rainer, Yvonne", "Atlas, Charles" ]
     more_people: ""
     title: "Interview with Charles Atlas (excerpt from Atlas’s *Rainer Variations*)"
     date: "2001–2"
@@ -7576,8 +7576,8 @@ object_list:
     id: "442"
     old_id: "8.08"
     maker: ""
-    people: ""
-    more_people: ""
+    people: [ "Rainer, Yvonne", "Atlas, Charles", "Move, Richard" ]
+    more_people: 
     title: "Yvonne Rainer attempting to teach *Trio A* to Martha Graham, impersonated by Richard Move in drag (excerpt from Charles Atlas’s *Rainer Variations*)"
     date: "2001–2"
     date_sort: "2001-01-01"
@@ -7593,7 +7593,7 @@ object_list:
     id: "443"
     old_id: "8.09"
     maker: ""
-    people: ""
+    people: [ "Rainer, Yvonne", "Atlas, Charles", "Chalfant, Kathleen" ]
     more_people: ""
     title: "Interview with Kathleen Chalfant (excerpt from Charles Atlas’s *Rainer Variations*)"
     date: "2001–2"
@@ -7627,8 +7627,8 @@ object_list:
     id: "445"
     old_id: "8.11"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
-    people: [ "Rainer, Yvonne" ]
-    more_people: ""
+    people: [ "Rainer, Yvonne", "Lloyd, Barbara", "Gordon, David", "Green, Nancy", "Paxton, Steve", "Scott, Lincoln" ]
+    more_people: [ "Ringgold, Faith", "Toche, Jean", "Hendricks, Jon" ]
     title: "*Trio A with Flags* (1966), performed at the opening of *The People’s Flag Show*, Judson Memorial Church, New York, NY"
     date: "9 November 1970"
     date_sort: "1970-11-09"
@@ -7644,7 +7644,7 @@ object_list:
     id: "446"
     old_id: "8.12"
     maker: ""
-    people: ""
+    people: [ "Rainer, Yvonne", "Hay, Deborah", "Rauschenberg, Robert", "Morris, Robert", "Gross, Sally", "Schlichter, Joseph", "Holder, Tony", "Hay, Alex" ]
     more_people: ""
     title: "Yvonne Rainer’s *We Shall Run* (1963), performed at the Wadsworth Atheneum, Hartford, CT"
     date: "7 March 1965"
@@ -7661,7 +7661,7 @@ object_list:
     id: "447"
     old_id: "8.13"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
-    people: [ "Rainer, Yvonne" ]
+    people: [ "Rainer, Yvonne", "Mangolte, Babette" ]
     more_people: ""
     title: "*We Shall Run* (1963), performed at Bennington College, Bennington, VT"
     date: "1980"
@@ -7730,7 +7730,7 @@ object_list:
     old_id: "8.17"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     people: [ "Rainer, Yvonne" ]
-    more_people: ""
+    more_people: [ "Dunn, Robert" ]
     title: "Pages from the score for *Watering Place* (ca. 1960)"
     date: "ca. 1960"
     date_sort: "1960-01-01"
@@ -7797,8 +7797,8 @@ object_list:
     id: "455"
     old_id: "8.21a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Rainer, Yvonne", "Gordon, David", "Paxton, Steve" ]
+    more_people: [ "Rauschenberg, Robert", "Corner, Philip" ]
     title: "Judson Dance Theater concert program for “A Dance Concert of Old and New Works by: David Gordon, Yvonne Rainer, Steve Paxton”"
     date: "10–12 January 1966"
     date_sort: "1966-01-10"
@@ -7815,7 +7815,7 @@ object_list:
     old_id: "8.21b"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
     people: [ "Rainer, Yvonne" ]
-    more_people: ""
+    more_people: [ "Gordon, William", "Paxton, Steve" ]
     title: "*The Mind Is a Muscle* concert program, Anderson Theater, New York, NY"
     date: "11, 14, 15 April 1968"
     date_sort: "1968-04-11"
@@ -7831,7 +7831,7 @@ object_list:
     id: "457"
     old_id: "8.21c"
     maker: [ "Don McDonagh (American, 1932–2019)" ]
-    people: [ "McDonagh, Don" ]
+    people: [ "McDonagh, Don", "Rainer, Yvonne" ]
     more_people: ""
     title: "“Miss Rainer Offers ‘Mind Is a Muscle,’” *New York Times*"
     date: "12 April 1968"
@@ -7848,8 +7848,8 @@ object_list:
     id: "458"
     old_id: "8.21d"
     maker: [ "Jill Johnston (American, 1929–2010)" ]
-    people: [ "Johnston, Jill" ]
-    more_people: ""
+    people: [ "Johnston, Jill", "Rainer, Yvonne" ]
+    more_people: [ "Rauschenberg, Robert", "Paxton, Steve", "Gordon, David"]
     title: "“Rainer’s ‘Mind Is a Muscle,’” *The Village Voice*, 13"
     date: "2 June 1966"
     date_sort: "1966-06-02"
@@ -7865,7 +7865,7 @@ object_list:
     id: "459"
     old_id: "8.21e"
     maker: [ "Jill Johnston (American, 1929–2010)" ]
-    people: [ "Johnston, Jill" ]
+    people: [ "Johnston, Jill", "Rainer, Yvonne" ]
     more_people: ""
     title: "“Rainer’s Muscle,” *The Village Voice*"
     date: "18 April 1968"
@@ -7882,8 +7882,8 @@ object_list:
     id: "460"
     old_id: "8.21f"
     maker: [ "Deborah Jowitt (American, b. 1934)" ]
-    people: [ "Jowitt, Deborah" ]
-    more_people: ""
+    people: [ "Jowitt, Deborah", "Rainer, Yvonne" ]
+    more_people: [ "Gordon, David", "Paxton, Steve" ]
     title: "“Expanded Muscle,” *The Village Voice*"
     date: "18 April 1968"
     date_sort: "1968-04-18"
@@ -7899,8 +7899,8 @@ object_list:
     id: "461"
     old_id: "8.21g"
     maker: [ "Jill Johnston (American, 1929–2010)" ]
-    people: [ "Johnston, Jill" ]
-    more_people: ""
+    people: [ "Johnston, Jill", "Rainer, Yvonne", "Cunningham, Merce" ]
+    more_people: [ "Paxton, Steve", "Brown, Trisha", "Dunn, Judith", "Davis, William", "Reid, Albert" ]
     title: "“Yvonne Rainer: I” and “Yvonne Rainer: II,” *The Village Voice*"
     date: "23 May 1963 and 6 June 1963"
     date_sort: "1963-05-23"
@@ -7917,7 +7917,7 @@ object_list:
     id: "462"
     old_id: "8.21h"
     maker: [ "Joan B. Cass" ]
-    people: [ "Cass, Joan B." ]
+    people: [ "Cass, Joan B.", "Rainer, Yvonne" ]
     more_people: ""
     title: "“Brandeis Offers Dance Contrasts,” *Boston Herald Traveler*"
     date: "16 January 1968"
@@ -7968,7 +7968,7 @@ object_list:
     id: "465"
     old_id: "8.23"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
-    people: [ "Rainer, Yvonne" ]
+    people: [ "Rainer, Yvonne", "Katz, Barbara" ]
     more_people: ""
     title: "Pages from the Labanotation score for Yvonne Rainer’s dances *Chair-Pillow* and *Couples,* from the larger project *Continuous Project Altered Daily* (1970), as performed at George Washington University, Washington, D.C."
     date: "1970"
@@ -8019,7 +8019,7 @@ object_list:
     id: "468"
     old_id: "8.26"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
-    people: [ "Rainer, Yvonne" ]
+    people: [ "Rainer, Yvonne", "Byars, James Lee" ]
     more_people: ""
     title: "“Some Thoughts on Improvisation (for the Painter James [Lee] Byars)”"
     date: "December 1963"
@@ -8070,7 +8070,7 @@ object_list:
     id: "471"
     old_id: "8.30"
     maker: [ "Yvonne Rainer (American, b. 1934)" ]
-    people: [ "Rainer, Yvonne" ]
+    people: [ "Rainer, Yvonne", "Childs, Lucinda", "Dunn, Judith", "Gross, Sally", "Hay, Deborah", "Holder, Tony", "Morris, Robert", "Paxton, Steve", "Rauschenberg, Robert", "Schlichter, Joseph" ]
     more_people: ""
     title: "Partial score for *Parts of Some Sextets*"
     date: "1965"
@@ -8190,7 +8190,7 @@ object_list:
     id: "478"
     old_id: "9.04"
     maker: [ "Tom Wasmuth (American, b. 1941)" ]
-    people: [ "Wasmuth, Tom" ]
+    people: [ "Wasmuth, Tom", "Knowles, Alison" ]
     more_people: ""
     title: "Diagram, 24 June 1969, in Alison Knowles’s *Journal of the Identical Lunch* (San Francisco: Nova Broadcast Press, 1971), 35"
     date: "1971"
@@ -8208,7 +8208,7 @@ object_list:
     old_id: "9.05"
     maker: [ "Alison Knowles (American, b. 1933)" ]
     people: [ "Knowles, Alison" ]
-    more_people: ""
+    more_people: [ "Williams, Emmett" ]
     title: "“Journal of the Identical Lunch,” *The Outsider* 2, no. 4/5 (Winter 1968/69): 182–84"
     date: "1968–69"
     date_sort: "1968-01-01"
@@ -8242,7 +8242,7 @@ object_list:
     id: "481"
     old_id: "9.07a"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Maciunas, George" ]
     more_people: ""
     title: "“Alison Knowles: *Identical Lunch Symphony*,” Logan Center for the Arts, University of Chicago"
     date: "5 May 2012"
@@ -8294,7 +8294,7 @@ object_list:
     id: "484"
     old_id: "9.08"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Maciunas, George" ]
     more_people: ""
     title: "*George Maciunas Performs The Identical Lunch*"
     date: "1969, realized 1973"
@@ -8328,7 +8328,7 @@ object_list:
     id: "486"
     old_id: "9.10"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Kubota, Shigeko" ]
     more_people: ""
     title: "*Shigeko Kubota Performs The Identical Lunch*"
     date: "1969, realized 1973"
@@ -8345,7 +8345,7 @@ object_list:
     id: "487"
     old_id: "9.11"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Brazeau, Anne" ]
     more_people: ""
     title: "*Anne Brazeau Performs The Identical Lunch*"
     date: "1969, realized 1973"
@@ -8362,7 +8362,7 @@ object_list:
     id: "488"
     old_id: "9.12"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Brown, Jean" ]
     more_people: ""
     title: "Letter from Alison Knowles to Jean Brown"
     date: "5 August ca. 1970s"
@@ -8380,7 +8380,7 @@ object_list:
     id: "489"
     old_id: "9.13"
     maker: [ "Alison Knowles (American, b. 1933)", "Anna (Annea) Lockwood (New Zealand-born American, b. 1939)" ]
-    people: [ "Knowles, Alison", "Lockwood, Anna (Annea)" ]
+    people: [ "Knowles, Alison", "Lockwood, Anna (Annea)", "Brown, Jean" ]
     more_people: ""
     title: "Letter from Alison Knowles to Jean Brown"
     date: "n.d."
@@ -8465,8 +8465,8 @@ object_list:
     id: "494"
     old_id: "9.19"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Knowles, Alison" ]
+    more_people: [ "Anderson, Laurie" ]
     title: "Brochure for the course “Meet the Woman Composer” at the New School for Social Research, New York, NY"
     date: "1976"
     date_sort: "1976-01-01"
@@ -8482,7 +8482,7 @@ object_list:
     id: "495"
     old_id: "9.21"
     maker: 
-    people: ""
+    people: [ "Knowles, Alison" ]
     more_people: ""
     title: "Xerox of “Alison Knowles,” in Miriam Shapiro’s *Art: A Woman’s Sensibility* (Valencia, CA: CalArts, 1975), 36"
     date: ""
@@ -8499,7 +8499,7 @@ object_list:
     id: "496"
     old_id: "9.22"
     maker: 
-    people: ""
+    people: [ "Knowles, Alison", "Corner, Philip" ]
     more_people: ""
     title: "Poster for Alison Knowles and Philip Corner’s *Food Mandala* at the Samaya Foundation, New York, NY"
     date: "1980"
@@ -8516,8 +8516,8 @@ object_list:
     id: "497"
     old_id: "9.23"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Knowles, Alison", "Lockwood, Anna", "Shiomi, Mieko", "Forti, Simone" ]
+    more_people: [ "Oliveros, Pauline" ]
     title: "Announcement for *Womens Work*, “a magazine of performance scores by contemporary women artists”"
     date: ""
     date_sort: ""
@@ -8533,7 +8533,7 @@ object_list:
     id: "498"
     old_id: "9.24"
     maker: 
-    people: ""
+    people: [ "Knowles, Alison" ]
     more_people: ""
     title: "Program for Alison Knowles’s *The Bean Garden* in “Meet the Woman Composer” at the New School for Social Research, New York, NY"
     date: "1976"
@@ -8550,8 +8550,8 @@ object_list:
     id: "499"
     old_id: "9.25"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Knowles, Alison" ]
+    more_people: [ "Kroesen, Jill", "Brown, Trisha" ]
     title: "Review of Knowles’s *The Bean Garden* at the New School, *Soho Weekly News*"
     date: "25 November 1976"
     date_sort: "1976-11-25"
@@ -8567,7 +8567,7 @@ object_list:
     id: "500"
     old_id: "9.26"
     maker: [ "Alison Knowles (American, b. 1933)" ]
-    people: [ "Knowles, Alison" ]
+    people: [ "Knowles, Alison", "Maciunas, George" ]
     more_people: ""
     title: "Postcard from Alison Knowles to George Maciunas"
     date: "25 August 1966"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -6707,7 +6707,7 @@ object_list:
     id: "391"
     old_id: "6.41"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Johnson, Jill" ]
     more_people: ""
     title: "“EVENTS: scores and other occurrences,” typescript, sent to Jill Johnston"
     date: "28 December 1961"
@@ -6724,7 +6724,7 @@ object_list:
     id: "392"
     old_id: "6.42"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Wolf, Daniel" ]
     more_people: ""
     title: "Letter from George Brecht to *The Village Voice* editor Daniel Wolf, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 4 (Cologne: Walther König, 1991), 178"
     date: "9 February 1960"
@@ -6758,8 +6758,8 @@ object_list:
     id: "394"
     old_id: "6.44"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Hansen, Al", "Brecht, George", "Feldman, Morton", "Cage, John", "Mac Low, Jackson", "Kaprow, Allan" ]
+    more_people: [ "Stockhausen, Karlheinz", "Henry, Pierre", "Schaeffer, Pierre" ]
     title: "Program for *A Program of Happenings ! Events ? & Situations !*, Pratt Institute, New York"
     date: "2 May 1960"
     date_sort: "1960-05-02"
@@ -6775,7 +6775,7 @@ object_list:
     id: "395"
     old_id: "6.45"
     maker: [ "Diane de Bonneval" ]
-    people: [ "Bonneval, Diane de" ]
+    people: [ "Bonneval, Diane de", "Brecht, George", "Cage, John", "Kaprow, Allan" ]
     more_people: ""
     title: "“New School’s ‘Happenings’ Proves to be ‘Hellzapoppin’-Beatnik Style,” *New York World-Telegram and The Sun*, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 5 (Cologne: Walther König, 1998), 89"
     date: "3 May 1960"
@@ -6792,8 +6792,8 @@ object_list:
     id: "396"
     old_id: "6.46"
     maker: [ "John Cage (American, 1912–92)" ]
-    people: [ "Cage, John" ]
-    more_people: ""
+    people: [ "Cage, John", "Brecht, George", "Tudor, David" ]
+    more_people: [ "Stockhausen, Karlheinz" ]
     title: "Letter from John Cage to George Brecht, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 5 (Cologne: Walther König, 1998), 114"
     date: "27 May 1960"
     date_sort: "1960-05-27"
@@ -6809,7 +6809,7 @@ object_list:
     id: "397"
     old_id: "6.47"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Brecht, George" ]
     more_people: ""
     title: "Letter from David Tudor to George Brecht, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 5 (Cologne: Walther König, 1998), 183"
     date: "27 July 1960"
@@ -6826,8 +6826,8 @@ object_list:
     id: "398"
     old_id: "6.48"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Ichiyanagi, Toshi", "Bussotti, Sylvano", "Brecht, George", "Young, La Monte" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Announcement for a David Tudor concert at Mary Bauermeister’s atelier, Cologne, Germany"
     date: "15 June 1960"
     date_sort: "1960-06-15"
@@ -6843,7 +6843,7 @@ object_list:
     id: "399"
     old_id: "6.49"
     maker: [ "Toshi Ichiyanagi (Japanese, b. 1933)" ]
-    people: [ "Ichiyanagi, Toshi" ]
+    people: [ "Ichiyanagi, Toshi", "Brecht, George", "Young, La Monte", "Cage, John", "Feldman, Morton" ]
     more_people: ""
     title: "Letter from Toshi Ichiyanagi to George Brecht, reprinted in *George Brecht—Notebooks*, ed. Dieter Daniels and Hermann Braun, vol. 7 (Cologne: Walther König, 2005), 26–27"
     date: "2 July 1961"
@@ -6860,7 +6860,7 @@ object_list:
     id: "400"
     old_id: "6.50"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Tudor, David", "Higgins, Dick" ]
     more_people: ""
     title: "*Mallard Milk*, event score sent to David Tudor"
     date: "summer 1961"
@@ -6877,7 +6877,7 @@ object_list:
     id: "401"
     old_id: "6.51"
     maker: [ "George Brecht (American, 1926–2008)", "Robert Watts (American, 1923–88)" ]
-    people: [ "Brecht, George", "Watts, Robert" ]
+    people: [ "Brecht, George", "Watts, Robert", "Richards, Mary Caroline" ]
     more_people: ""
     title: "*Lantern Extract*, envelope and seventeen scores sent to M. C. Richards"
     date: "late 1962"
@@ -6894,7 +6894,7 @@ object_list:
     id: "402"
     old_id: "6.52"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Johnston, Jill", "Cage, John" ]
     more_people: ""
     title: "Letters from George Brecht to Jill Johnston"
     date: "ca. 1963"
@@ -6911,7 +6911,7 @@ object_list:
     id: "403"
     old_id: "6.53"
     maker: [ "George Brecht (American, 1926–2008)" ]
-    people: [ "Brecht, George" ]
+    people: [ "Brecht, George", "Richards, Mary Caroline" ]
     more_people: ""
     title: "Letter from George Brecht to M. C. Richards"
     date: "July 1963"
@@ -6928,7 +6928,7 @@ object_list:
     id: "404"
     old_id: "7.01"
     maker: 
-    people: ""
+    people: [ "Mac Low, Jackson" ]
     more_people: ""
     title: "Interactive map of locations relevant to the creation and distribution of Jackson Mac Low’s postcard scores"
     date: "spring 1963"
@@ -6964,8 +6964,8 @@ object_list:
     id: "406"
     old_id: "7.05"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
-    more_people: ""
+    people: [ "Mac Low, Jackson", "Patterson, Ben", "Brecht, George" ]
+    more_people: [ "Flynt, Hery" ]
     title: "Postcards sent by Jackson Mac Low to Benjamin Patterson with various scores composed in 1963, including *Social Projects 1–3*, *Architecture (for GB)*, *Schedule (for George Brecht)*, and *Light Rhythms for Henry Flynt*"
     date: "April 1963"
     date_sort: "1963-04-01"
@@ -6998,7 +6998,7 @@ object_list:
     id: "408"
     old_id: "7.08"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Richards, Mary Caroline" ]
     more_people: ""
     title: "Letter from Jackson Mac Low to M. C. Richards in Stony Point, NY"
     date: "1 February 1955"
@@ -7015,7 +7015,7 @@ object_list:
     id: "409"
     old_id: "7.09"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Richards, Mary Caroline" ]
     more_people: ""
     title: "Typescript of “Biblical Poems” 1–3, enclosed with a letter to M. C. Richards"
     date: "1955"
@@ -7032,7 +7032,7 @@ object_list:
     id: "410"
     old_id: "7.10"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Tudor, David", "Richards, Mary Caroline", "Cage, John" ]
     more_people: ""
     title: "Envelope for a letter from Jackson Mac Low to David Tudor, John Cage, and M. C. Richards in Stony Point, NY"
     date: "10 February 1955"
@@ -7049,7 +7049,7 @@ object_list:
     id: "411"
     old_id: "7.11"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Cage, John" ]
     more_people: ""
     title: "Letter from Jackson Mac Low to John Cage in Stony Point, NY"
     date: "ca. 10 February 1955"
@@ -7066,7 +7066,7 @@ object_list:
     id: "412"
     old_id: "7.12"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Tudor, David" ]
     more_people: ""
     title: "Letter from Jackson Mac Low to David Tudor in Stony Point, NY"
     date: "ca. 10 February 1955"
@@ -7083,7 +7083,7 @@ object_list:
     id: "413"
     old_id: "7.13"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Richards, Mary Caroline" ]
     more_people: ""
     title: "Letter from Jackson Mac Low to M. C. Richards in Stony Point, NY"
     date: "ca. 10 February 1955"
@@ -7100,7 +7100,7 @@ object_list:
     id: "414"
     old_id: "7.14"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Richards, Mary Caroline" ]
     more_people: ""
     title: "Typescript of “Biblical Poems” 4–5, enclosed with a letter to M. C. Richards"
     date: "1955"
@@ -7117,7 +7117,7 @@ object_list:
     id: "415"
     old_id: "7.23"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Tudor, David", "Cage, John", "Richards, Mary Caroline" ]
     more_people: ""
     title: "Fragment of a letter from Jackson Mac Low to David Tudor, John Cage, and M. C. Richards in Stony Point, NY"
     date: "10 February 1955"
@@ -7134,7 +7134,7 @@ object_list:
     id: "416"
     old_id: "7.16"
     maker: [ "Angus MacLise (American, 1938–79)" ]
-    people: [ "MacLise, Angus" ]
+    people: [ "MacLise, Angus", "Mac Low, Jackson" ]
     more_people: ""
     title: "*Year* (New York: Dead Language, 1962)"
     date: "1962"
@@ -7168,8 +7168,8 @@ object_list:
     id: "418"
     old_id: "7.18"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
-    more_people: ""
+    people: [ "Maciunas, George", "Brecht, George", "Kaprow, Allan", "Mac Low, Jackson", "Patterson, Ben", "Young, La Monte", "De Maria, Walter", "Ono, Yoko", "Ichiyanagi, Toshi" ]
+    more_people: [ "Paik, Nam June", "Higgins, Dick", "Vautier, Ben" ]
     title: "*Fluxus News–Policy Letter, no. 6*"
     date: "6 April 1963"
     date_sort: "1963-04-06"
@@ -7185,7 +7185,7 @@ object_list:
     id: "419"
     old_id: "7.19"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Maciunas, George" ]
     more_people: ""
     title: "Open letter from Jackson Mac Low to George Maciunas in response to *Fluxus News—Policy Letter, no. 6*"
     date: "25 April 1963"
@@ -7202,7 +7202,7 @@ object_list:
     id: "420"
     old_id: "7.20"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Spoerri, Daniel", "Williams, Emmett", "Filliou, Robert" ]
     more_people: ""
     title: "Postcards from Jackson Mac Low to Daniel Spoerri, Emmett Williams, and Robert Filliou, with scores for *Social Projects 1–3*"
     date: "29 April 1963"
@@ -7219,8 +7219,8 @@ object_list:
     id: "421"
     old_id: "7.21"
     maker: [ "George Maciunas (Lithuanian American, 1931–78)" ]
-    people: [ "Maciunas, George" ]
-    more_people: ""
+    people: [ "Maciunas, George", "Brecht, George", "Kaprow, Allan", "Mac Low, Jackson", "Patterson, Benjamin", "Young, La Monte", "De Maria, Walter", "Ono, Yoko", "Ichiyanagi, Toshi", "Shiomi, Chieko", "Knowles, Alison" ]
+    more_people: [ "Paik, Nam June", "Higgins, Dick", "Vautier, Ben", "Ligeti, Gyorgy", "Kosugi, Takehisa" ]
     title: "*Fluxus News—Policy Letter, no. 7*, reprinted in *Fluxus etc., Addenda 1*, ed. Jon Hendricks (New York: Ink &, 1983), 157–59"
     date: "1 May 1963"
     date_sort: "1963-05-01"
@@ -7236,8 +7236,8 @@ object_list:
     id: "422"
     old_id: "7.25"
     maker: [ "Barbara Moore (American)", "Jon Hendricks (American, b. 1940)" ]
-    people: [ "Moore, Barbara", "Hendricks, Jon" ]
-    more_people: ""
+    people: [ "Moore, Barbara", "Hendricks, Jon", "Mac Low, Jackson", "Cunningham, Merce", "Patterson, Benjamin" ]
+    more_people: [ "Moorman, Charolette", "Neuhaus, Max", "Tenney, James", "Dunn, Robert" ]
     title: "Inventory and price list for Jackson Mac Low items for sale from Backworks"
     date: "summer 1977"
     date_sort: "1977-06-01"
@@ -7253,8 +7253,8 @@ object_list:
     id: "423"
     old_id: "7.27"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Mac Low, Jackson", "Patterson, Benjamin", "Cage, John", "Forti, Simone", "Young, La Monte" ]
+    more_people: [ "Corner, Philip", "Schneemann, Carolee", "Higgins, Dick", "Zazeela, Marian" ]
     title: "Program for “Jackson Mac Low Retrospective Concert—In Celebration of His 60th Birthday”"
     date: "12 September 1982"
     date_sort: "1982-09-12"
@@ -7270,8 +7270,8 @@ object_list:
     id: "424"
     old_id: "7.28"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Mac Low, Jackson" ]
+    more_people: [ "Ginsburg, Allen", "Corner, Philip" ]
     title: "Poster for a “peace illumination walk” in sympathy with the suffering in Vietnam"
     date: "23 December 1966"
     date_sort: "1966-12-23"
@@ -7287,8 +7287,8 @@ object_list:
     id: "425"
     old_id: "7.29"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Mac Low, Jackson", "Cage, John", "Forti, Simone", "Young, La Monte" ]
+    more_people: [ "Schneemann, Carolee" ]
     title: "Press release for a Jackson Mac Low retrospective concert"
     date: "1982"
     date_sort: "1982-01-01"
@@ -7304,8 +7304,8 @@ object_list:
     id: "426"
     old_id: "7.30"
     maker: [ "Anne Tardos (American, b. 1943)" ]
-    people: [ "Tardos, Anne" ]
-    more_people: ""
+    people: [ "Tardos, Anne", "Mac Low, Jackson", "Cage, John", "Forti, Simone", "Knowles, Alison", "Young, La Monte" ]
+    more_people: [ "Corner, Philip", "Higgins, Dick", "Monk, Meredith", "Oliveros, Pauline", "Paik, Nam June", "Schneemann, Carolee", "Zazeela, Marian" ]
     title: "Poster for a Jackson Mac Low retrospective concert at Washington Square Church, New York, NY"
     date: "1982"
     date_sort: "1982-01-01"
@@ -7321,7 +7321,7 @@ object_list:
     id: "427"
     old_id: "7.31"
     maker: [ "Jackson Mac Low (American, 1922–2004)" ]
-    people: [ "Mac Low, Jackson" ]
+    people: [ "Mac Low, Jackson", "Higgins, Dick" ]
     more_people: ""
     title: "Flyer for “Jackson Mac Low: Verbal/Musical Works” at The Kitchen, New York, NY, sent by Mac Low to Dick Higgins"
     date: "30 May 1978"
@@ -7338,7 +7338,7 @@ object_list:
     id: "428"
     old_id: "7.32"
     maker: 
-    people: ""
+    people: [ "Mac Low, Jackson" ]
     more_people: ""
     title: "Flyer for “Waltspacer: An Audiovisual Simultaneity” at Loeb Student Center, New York University, New York, NY"
     date: "23 April 1969"
@@ -7355,7 +7355,7 @@ object_list:
     id: "429"
     old_id: "7.33"
     maker: 
-    people: ""
+    people: [ "Mac Low, Jackson", "Cunningham, Merce" ]
     more_people: ""
     title: "Program for “Jackson Mac Low with Merce Cunningham and Dance Company” at Cunningham Studio at Westbeth, New York, NY"
     date: "16–17 February 1974"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1468,8 +1468,8 @@ object_list:
     id: "085"
     old_id: "2.14c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Cunningham, Merce" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "Program for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1485,7 +1485,7 @@ object_list:
     id: "086"
     old_id: "2.14d"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David", "Cunningham, Merce" ]
     more_people: ""
     title: "Program for Village Vanguard performance"
     date: "1958"
@@ -1502,8 +1502,8 @@ object_list:
     id: "087"
     old_id: "2.14e"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Bussotti, Sylvano" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Program for a concert by David Tudor and John Cage at Ann Arbor High School, Michigan, sponsored by the Dramatic Arts Center"
     date: "16 May 1960"
     date_sort: "1960-05-16"
@@ -1519,8 +1519,8 @@ object_list:
     id: "088"
     old_id: "2.14f"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David" ]
+    more_people: [ "Cardew, Cornelius", "Stockhausen, Karlheinz" ]
     title: "Program for Musik der Zeit, Westdeutscher Rundfunk Köln, Germany"
     date: "19 September 1958"
     date_sort: "1958-09-19"
@@ -1536,7 +1536,7 @@ object_list:
     id: "089"
     old_id: "2.14g"
     maker: 
-    people: ""
+    people: [ "Cunningham, Merce", "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "Program for *Antic Meet* performance of John Cage’s *Solo for Piano*, Eleventh American Dance Festival, Connecticut College"
     date: "14 August 1958"
@@ -1553,7 +1553,7 @@ object_list:
     id: "090"
     old_id: "2.14h"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cage, John", "Cunningham, Merce" ]
     more_people: ""
     title: "Program for *Antic Meet* performance of John Cage’s *Solo for Piano*, Twelfth American Dance Festival, Connecticut College"
     date: "13 August 1959"
@@ -1570,8 +1570,8 @@ object_list:
     id: "091"
     old_id: "2.14i"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Feldman, Morton", "Brown, Earle", "Bussotti, Sylvano", "Tudor, David" ]
+    more_people: [ "Wolff, Christian", "Cardew, Cornelius" ]
     title: "Program for Die Reihe III [Third series], Musikalische Jugend Österreichs, Internationale Gesellschaft für Neue Musik"
     date: "19 November 1959"
     date_sort: "1959-11-19"
@@ -1587,7 +1587,7 @@ object_list:
     id: "092"
     old_id: "2.14j"
     maker: [ "John Cage (American, 1912–92)", "Richard Kostelanetz (b. 1940)" ]
-    people: [ "Cage, John", "Kostelanetz, Richard" ]
+    people: [ "Cage, John", "Kostelanetz, Richard", "Tudor, David" ]
     more_people: ""
     title: "Liner notes for *Indeterminacy* recording"
     date: "1959; reissued 1992"
@@ -1604,8 +1604,8 @@ object_list:
     id: "093"
     old_id: "2.14k"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Bussotti, Sylvano", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz", "Boulez, Pierre" ] 
     title: "Promotional collage of clippings and scores for a concert at the First Unitarian Society, Minneapolis, MN, printed in *The Potboiler* (January and February 1962)"
     date: "22 January 1961"
     date_sort: "1961-01-22"
@@ -1621,8 +1621,8 @@ object_list:
     id: "094"
     old_id: "2.15a"
     maker: [ "H. G." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John" ]
+    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
     title: "“Mäßiger Auftakt in Köln: Drei Premieren, darunter eine mit Wäscheklammern,” *Neue Rhein Zeitung*"
     date: "25 September 1958"
     date_sort: "1958-09-25"
@@ -1638,7 +1638,7 @@ object_list:
     id: "095"
     old_id: "2.15b"
     maker: [ "Dore Ashton" ]
-    people: [ "Ashton, Dore" ]
+    people: [ "Ashton, Dore", "Cage, John" ]
     more_people: ""
     title: "“Cage, Composer, Shows Calligraphy of Note,” review of the Stable Gallery show, *New York Times*"
     date: "6 May 1958"
@@ -1655,7 +1655,7 @@ object_list:
     id: "096"
     old_id: "2.15c"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“A Whistle, a ‘Slinky’ and a Bunch of Screws,” photograph by Sy Friedman, *New York Times*, X9"
     date: "11 May 1958"
@@ -1672,8 +1672,8 @@ object_list:
     id: "097"
     old_id: "2.15d"
     maker: [ "Jay S. Harrison" ]
-    people: [ "Harrison, Jay S." ]
-    more_people: ""
+    people: [ "Harrison, Jay S.", "Cage, John", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“John Cage Retrospective Is Presented at Town Hall,” *New York Herald Tribune*, 12"
     date: "16 May 1958"
     date_sort: "1958-05-16"
@@ -1689,8 +1689,8 @@ object_list:
     id: "098"
     old_id: "2.15e"
     maker: [ "Milew Kastendieck" ]
-    people: [ "Kastendieck, Milew" ]
-    more_people: ""
+    people: [ "Kastendieck, Milew", "Cage, John" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“Cage’s Music Still a Phenomenon,” *New York Journal-American*, 12"
     date: "16 May 1958"
     date_sort: "1958-05-16"
@@ -1706,8 +1706,8 @@ object_list:
     id: "099"
     old_id: "2.15f"
     maker: [ "Ross Parmenter" ]
-    people: [ "Parmenter, Ross" ]
-    more_people: ""
+    people: [ "Parmenter, Ross", "Cage, John", "Tudor, David", "Cuningham, Merce" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“Music: Experimenter: Zounds! Sound by John Cage at Town Hall,” *New York Times*, 20"
     date: "16 May 1958"
     date_sort: "1958-05-16"
@@ -1723,7 +1723,7 @@ object_list:
     id: "100"
     old_id: "2.15g"
     maker: [ "Louis Biancolli" ]
-    people: [ "Biancolli, Louis" ]
+    people: [ "Biancolli, Louis", "Cage, John" ]
     more_people: ""
     title: "“John Cage Gives Review of Work,” *New York World-Telegram and Sun*, 25"
     date: "16 May 1958"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -207,7 +207,7 @@ object_list:
     id: "012"
     old_id: "1.01"
     maker: [ "Morton Feldman (American, 1926–87)" ]
-    people: [ "Feldman, Morton" ]
+    people: [ "Feldman, Morton", "Tudor, David" ]
     more_people: ""
     title: "*Intersection 3* with a dedication to David Tudor"
     date: "1953"
@@ -241,7 +241,7 @@ object_list:
     id: "014"
     old_id: "1.03"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Realization of Morton Feldman’s *Intersection 3*"
     date: "1953"
@@ -258,7 +258,7 @@ object_list:
     id: "015"
     old_id: "1.04"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Rereleased recording of David Tudor performing *Intersection 3*"
     date: "2007"
@@ -275,7 +275,7 @@ object_list:
     id: "016"
     old_id: "1.05"
     maker: [ "David Tudor (American, 1926–96)" ]
-    people: [ "Tudor, David" ]
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Undated recording of David Tudor performing *Intersection 3*"
     date: ""
@@ -326,7 +326,7 @@ object_list:
     id: "019"
     old_id: "1.07a"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Animated score of David Tudor’s *Intersection 3* performance"
     date: "1953"
@@ -343,7 +343,7 @@ object_list:
     id: "020"
     old_id: "1.07b"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Feldman, Morton" ]
     more_people: ""
     title: "Audio sampler of Tudor’s sonorities for *Intersection 3*"
     date: "1953"
@@ -360,7 +360,7 @@ object_list:
     id: "021"
     old_id: "1.08"
     maker: [ "Morton Feldman (American, 1926–87)" ]
-    people: [ "Feldman, Morton" ]
+    people: [ "Feldman, Morton", "Tudor, David" ]
     more_people: ""
     title: "Letter from Morton Feldman to David Tudor"
     date: "15 June 1953"
@@ -411,8 +411,8 @@ object_list:
     id: "024"
     old_id: "1.11a"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Boulez, Pierre", "Wolff, Christian" ]
     title: "Program for a concert featuring David Tudor at the Festival of Contemporary Arts, University of Illinois School of Music"
     date: "22 March 1953"
     date_sort: "1953-03-22"
@@ -428,8 +428,8 @@ object_list:
     id: "025"
     old_id: "1.11b"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz", "Pousseur, Henri" ]
     title: "Program for Musik der Zeit, featuring David Tudor and John Cage at Nordwestdeutscher Rundfunk Köln"
     date: "26 November 1954"
     date_sort: "1954-11-26"
@@ -445,8 +445,8 @@ object_list:
     id: "026"
     old_id: "1.11c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian" ]
     title: "Program for a concert featuring David Tudor and John Cage at the University of British Columbia"
     date: "2 December 1955"
     date_sort: "1955-12-02"
@@ -462,8 +462,8 @@ object_list:
     id: "027"
     old_id: "1.11d"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Webern, Anton", "Boulez, Pierre", "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "“WHRB Presents David Tudor, Pianist, & John Cage in a Program for ‘New’ Music for Piano at Harvard University”"
     date: "20 April 1956"
     date_sort: "1956-04-20"
@@ -479,8 +479,8 @@ object_list:
     id: "028"
     old_id: "1.11e"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John", "Brown, Earle", "Feldman, Morton" ]
+    more_people: [ "Wolff, Christian", "Stockhausen, Karlheinz" ]
     title: "Program for a concert featuring David Tudor at the Vortragssaal at the Akademie für Musik und darstellende Kunst"
     date: "30 November 1956"
     date_sort: "1956-11-30"
@@ -496,8 +496,8 @@ object_list:
     id: "029"
     old_id: "1.11f"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Stockhausen, Karlheinz", "Wolff, Christian" ]
     title: "Program for a performance featuring David Tudor and John Cage"
     date: "n.d."
     date_sort: ""
@@ -513,8 +513,8 @@ object_list:
     id: "030"
     old_id: "1.12a"
     maker: [ "George W. Stowe" ]
-    people: [ "Stowe, George W." ]
-    more_people: ""
+    people: [ "Stowe, George W.", "Cage, John", "Tudor, David", "Feldman, Morton", "Brown, Earle" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Varese, Edgar" ]
     title: "“David Tudor Program Opens Sunday Afternoon Series,” *Hartford Times*"
     date: "November 1953"
     date_sort: "1953-11-01"
@@ -530,7 +530,7 @@ object_list:
     id: "031"
     old_id: "1.12b"
     maker: 
-    people: ""
+    people: [ "Tudor, David", "Cunningham, Merce" ]
     more_people: ""
     title: "“Merce Cunningham of New York”"
     date: "August 1953?"
@@ -548,8 +548,8 @@ object_list:
     id: "032"
     old_id: "1.12c"
     maker: 
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cunningham, Merce" ]
+    more_people: [ "Wolpe, Stefan" ]
     title: "“Concerts Are Arranged at College,” *Asheville Citizen-Times*"
     date: "21 June 1953"
     date_sort: "1953-06-21"

--- a/content/_data/objects.yaml
+++ b/content/_data/objects.yaml
@@ -1451,8 +1451,8 @@ object_list:
     id: "084"
     old_id: "2.14b"
     maker: 
-    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David", "Richards, Mary Caroline" ]
-    more_people: [ "Ajemian, Maro" ]
+    people: [ "Cage, John", "Cunningham, Merce", "Tudor, David" ]
+    more_people: [ "Ajemian, Maro", "Richards, Mary Caroline" ]
     title: "Press release for John Cage’s twenty-five-year retrospective concert at Town Hall"
     date: "May 1958"
     date_sort: "1958-05-01"
@@ -1740,8 +1740,8 @@ object_list:
     id: "101"
     old_id: "2.15h"
     maker: [ "Margaret Lloyd" ]
-    people: [ "Lloyd, Margaret" ]
-    more_people: ""
+    people: [ "Lloyd, Margaret", "Cage, John", "Cunningham, Merce", "Feldman, Morton", "Tudor, David" ]
+    more_people: [ "Rauschenberg, Robert" ]
     title: "“Modern American Dance in Connecticut: Contrasting Styles Seen in Eleventh Annual,” *Christian Science Monitor*"
     date: "23 August 1958"
     date_sort: "1958-08-23"
@@ -1757,7 +1757,7 @@ object_list:
     id: "102"
     old_id: "2.15i"
     maker: [ "H. R." ]
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“In der Werkstatt der direktiven Freiheit,” *Kölnische Rundschau*"
     date: "21 September 1958"
@@ -1774,8 +1774,8 @@ object_list:
     id: "103"
     old_id: "2.15j"
     maker: [ "M. F." ]
-    people: ""
-    more_people: ""
+    people: [ "Cage, John", "Tudor, David" ]
+    more_people: [ "Boulez, Pierre", "Stockhausen, Karlheinz" ]
     title: "“Ein Ding mit Pfiff: Avantgardisten im ersten Abend ‘Musik der Zeit,’” *Neue Rhein Zeitung*"
     date: "22 September 1958"
     date_sort: "1958-09-22"
@@ -1791,8 +1791,8 @@ object_list:
     id: "104"
     old_id: "2.15k"
     maker: [ "Herbert Schultz" ]
-    people: [ "Schultz, Herbert" ]
-    more_people: ""
+    people: [ "Schultz, Herbert", "Cage, John", "Tudor, David" ]
+    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
     title: "“Nicht mehr der Ton macht die Musik,” *Der Mittag*"
     date: "23 September 1958"
     date_sort: "1958-09-23"
@@ -1808,8 +1808,8 @@ object_list:
     id: "105"
     old_id: "2.15l"
     maker: [ "Diether de la Motte" ]
-    people: [ "de la Motte, Diether" ]
-    more_people: ""
+    people: [ "de la Motte, Diether", "Cage, John", "Tudor, David" ]
+    more_people: [ "Boulez, Pierre", "Stockhausen, Karlheinz" ]
     title: "“Musik der Zeit: Demonstration neuer Kompositionstechniken,” *Rheinische Post*"
     date: "23 September 1958"
     date_sort: "1958-09-23"
@@ -1825,7 +1825,7 @@ object_list:
     id: "106"
     old_id: "2.15m"
     maker: [ "HvL" ]
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“Im Klavierkonzert ging es absunderlich her,” *Westdeutsche Rundschau Wuppertal*"
     date: "23 September 1958"
@@ -1842,8 +1842,8 @@ object_list:
     id: "107"
     old_id: "2.15n"
     maker: [ "Friedrich Berger" ]
-    people: [ "Berger, Friedrich" ]
-    more_people: ""
+    people: [ "Berger, Friedrich", "Cage, John", "Tudor, David"  ]
+    more_people: [ "Stockhausen, Karlheinz", "Boulez, Pierre" ]
     title: "“Alibi für die Gestrigen,” *Kölner Stadt-Anzeiger*"
     date: "24 September 1958"
     date_sort: "1958-09-24"
@@ -1859,7 +1859,7 @@ object_list:
     id: "108"
     old_id: "2.15o"
     maker: [ "Heinrich Lindlar" ]
-    people: [ "Lindlar, Heinrich" ]
+    people: [ "Lindlar, Heinrich", "Cage, John" ]
     more_people: ""
     title: "“Was man hörte, war verwirrend: Fragwürdiges Funk-Konzert aus Köln mit ‘Musik der Zeit,’” *Die Welt*"
     date: "25 September 1958"
@@ -1876,7 +1876,7 @@ object_list:
     id: "109"
     old_id: "2.15p"
     maker: [ "Kurt Driesch" ]
-    people: [ "Driesch, Kurt" ]
+    people: [ "Driesch, Kurt", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“‘Avantgardistische Musik’ am Abgrund: Europäische Erstauffühurng von John Cage’s ‘Klavierkonzert’ in Köln,” *Rhein Neckar-Azeitung*"
     date: "30 September 1958"
@@ -1893,7 +1893,7 @@ object_list:
     id: "110"
     old_id: "2.15q"
     maker: [ "H. H. Stuckenschmidt" ]
-    people: [ "Stuckenschmidt, H. H." ]
+    people: [ "Stuckenschmidt, H. H.", "Tudor, David", "Cage, John" ]
     more_people: ""
     title: "“Sessions on Modern Music Held Near Darmstadt,” *Musical America*, 18–19, 34"
     date: "October 1958"
@@ -1910,8 +1910,8 @@ object_list:
     id: "111"
     old_id: "2.15r"
     maker: [ "A. H." ]
-    people: ""
-    more_people: ""
+    people: [ "Tudor, David", "Cage, John" ]
+    more_people: [ "Wolff, Christian", "Boulez, Pierre", "Pousseur, Henri", "Messaien, Olivier" ]
     title: "“David Tudor in Piano Recital,” *New York Herald Tribune*, 11"
     date: "20 March 1959"
     date_sort: "1959-03-20"
@@ -1927,7 +1927,7 @@ object_list:
     id: "112"
     old_id: "2.15s"
     maker: [ "Edward Cannel" ]
-    people: [ "Cannel, Edward" ]
+    people: [ "Cannel, Edward", "Cage, John" ]
     more_people: ""
     title: "“Little Thing Like Mushroom Can Change Destiny,” *Oregon Journal*"
     date: "5 July 1959"
@@ -1944,8 +1944,8 @@ object_list:
     id: "113"
     old_id: "2.15t"
     maker: [ "Doris Hering" ]
-    people: [ "Hering, Doris" ]
-    more_people: ""
+    people: [ "Hering, Doris", "Tudor, David", "Cunningham, Merce" ]
+    more_people: [ "Shearer, Sybil" ]
     title: "“The ‘Good Guys’ Versus the ‘Bad Guys’: Twelfth American Dance Festival,” *Dance Magazine*, 31–35, 82"
     date: "October 1959"
     date_sort: "1959-10-01"
@@ -1961,7 +1961,7 @@ object_list:
     id: "114"
     old_id: "2.15u"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“John Cage: Indeterminacy,” *Time*, 65"
     date: "2 November 1959"
@@ -1978,7 +1978,7 @@ object_list:
     id: "115"
     old_id: "2.15v"
     maker: 
-    people: ""
+    people: [ "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“Tumulte im Mozart-Saal des Konzerthauses,” *Neues Österreich*"
     date: "21 November 1959"
@@ -1995,7 +1995,7 @@ object_list:
     id: "116"
     old_id: "2.15w"
     maker: [ "Eric Salzman" ]
-    people: [ "Salzman, Eric" ]
+    people: [ "Salzman, Eric", "Cage, John", "Tudor, David" ]
     more_people: ""
     title: "“John Cage in Story Hour for Some Friends,” *New York Times*"
     date: "26 January 1960"
@@ -2012,8 +2012,8 @@ object_list:
     id: "117"
     old_id: "2.15x"
     maker: [ "Fred Grunfeld" ]
-    people: [ "Grunfeld, Fred" ]
-    more_people: ""
+    people: [ "Grunfeld, Fred", "Cage, John", "Feldman, Morton" ]
+    more_people: [ "Ajemian, Maro" ]
     title: "“Cage Without Bars,” *The Reporter*, 35, 37"
     date: "4 February 1960"
     date_sort: "1960-02-04"
@@ -2029,8 +2029,8 @@ object_list:
     id: "118"
     old_id: "2.15y"
     maker: [ "Walter Terry" ]
-    people: [ "Terry, Walter" ]
-    more_people: ""
+    people: [ "Terry, Walter", "Cunningham, Merce", "Cage, John", "Feldman, Morton", "Tudor, David" ]
+    more_people: [ "Wolff, Christian" ]
     title: "“Cunningham Dance Group Gives Avant Garde Works,” *New York Herald Tribune*, 19"
     date: "17 February 1960"
     date_sort: "1960-02-17"
@@ -2046,8 +2046,8 @@ object_list:
     id: "119"
     old_id: "2.15z"
     maker: [ "Paul Henry Lang" ]
-    people: [ "Lang, Paul Henry" ]
-    more_people: ""
+    people: [ "Lang, Paul Henry", "Tudor, David" ]
+    more_people: [ "Carter, Elliott" ]
     title: "“What Is Offered by Electronic Age?,” *New York Herald Tribune*, 6"
     date: "10 April 1960"
     date_sort: "1960-04-10"
@@ -2063,7 +2063,7 @@ object_list:
     id: "120"
     old_id: "2.15ab"
     maker: [ "John K. Sherman" ]
-    people: [ "Sherman, John K." ]
+    people: [ "Sherman, John K.", "Tudor, David", "Cage, John", "Bussotti, Sylvano" ]
     more_people: ""
     title: "“Music to Hear—and Unhear,” *Minneapolis Star*"
     date: "1961"


### PR DESCRIPTION
Closed the old PR and re-opened in the same branch (because nothing was merged)...let me know if I am doing this correctly! 

So here is the next 100 with three I flagged for your review: 

-id 112: Cage is the only person discussed in the article so I added only him to "people" (along with press author already listed from automation). But MC Richards, Tudor, and Cunningham are briefly listed in extended caption. 

-id 165. Example of “Piano Pieces for David Tudor” being nested within a larger Bussotti composition. Is Tudor a “people” here, then? He seems a little bit removed from the object at hand. 

-id 195. These are Tudor's lecture notes where he briefly writes about being indebted to Feldman (which is stated in the extended caption)--should Feldman be included in "people"? 

